### PR TITLE
Rewrite plugin to authenticate via OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,15 @@ The plugin is composed of a few distinct pieces:
   on which Permanent Archive to store the pad in
 - The back-end needs to listen on an API for that information, and persist it
 - The back-end needs to wait for updates to a pad, and sync it to Permanent
+
+### Authentication
+
+The plugin uses OAuth to authenticate to Permanent.
+
+The OAuth Authorization Code Grant flow starts from the server, which can
+securely use the IdP-issued client credentials without exposing them to the
+user. The server requests a refresh token, which it can use to continue to sync
+a user's pads until the refresh token expires.
+
+The token is stored in the database, under the key `permanent:{authorId}`.
+Individual pads are configured u

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,9 @@
     "@permanentorg/node-sdk": {
       "version": "file:../node-sdk",
       "requires": {
-        "axios": "^0.21.1"
+        "axios": "^0.21.2",
+        "joi": "^17.4.3",
+        "simple-oauth2": "^4.2.0"
       },
       "dependencies": {
         "@ava/typescript": {
@@ -478,6 +480,42 @@
             }
           }
         },
+        "@hapi/boom": {
+          "version": "9.1.4",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+          "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+          "requires": {
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/bourne": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+          "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
+        },
+        "@hapi/hoek": {
+          "version": "9.2.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+          "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
+        },
+        "@hapi/topo": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+          "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+          "requires": {
+            "@hapi/hoek": "^9.0.0"
+          }
+        },
+        "@hapi/wreck": {
+          "version": "17.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.1.0.tgz",
+          "integrity": "sha512-nx6sFyfqOpJ+EFrHX+XWwJAxs3ju4iHdbB/bwR8yTNZOiYmuhA8eCe7lYPtYmb4j7vyK/SlbaQsmTtUrMvPEBw==",
+          "requires": {
+            "@hapi/boom": "9.x.x",
+            "@hapi/bourne": "2.x.x",
+            "@hapi/hoek": "9.x.x"
+          }
+        },
         "@istanbuljs/load-nyc-config": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -525,6 +563,24 @@
             "@nodelib/fs.scandir": "2.1.3",
             "fastq": "^1.6.0"
           }
+        },
+        "@sideway/address": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",
+          "integrity": "sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==",
+          "requires": {
+            "@hapi/hoek": "^9.0.0"
+          }
+        },
+        "@sideway/formula": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+          "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+        },
+        "@sideway/pinpoint": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+          "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
         },
         "@sindresorhus/is": {
           "version": "0.14.0",
@@ -1052,11 +1108,11 @@
           }
         },
         "axios": {
-          "version": "0.21.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
           "requires": {
-            "follow-redirects": "^1.10.0"
+            "follow-redirects": "^1.14.0"
           }
         },
         "axios-mock-adapter": {
@@ -3710,9 +3766,9 @@
           "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
         },
         "follow-redirects": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-          "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+          "version": "1.14.7",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+          "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
         },
         "for-in": {
           "version": "1.0.2",
@@ -5274,6 +5330,18 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/iterable-to-stream/-/iterable-to-stream-1.0.1.tgz",
           "integrity": "sha512-O62gD5ADMUGtJoOoM9U6LQ7i4byPXUNoHJ6mqsmkQJcom331ZJGDApWgDESWyBMEHEJRjtHozgIiTzYo9RU4UA=="
+        },
+        "joi": {
+          "version": "17.5.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-17.5.0.tgz",
+          "integrity": "sha512-R7hR50COp7StzLnDi4ywOXHrBrgNXuUUfJWIR5lPY5Bm/pOD3jZaTwpluUXVLRWcoWZxkrHBBJ5hLxgnlehbdw==",
+          "requires": {
+            "@hapi/hoek": "^9.0.0",
+            "@hapi/topo": "^5.0.0",
+            "@sideway/address": "^4.1.3",
+            "@sideway/formula": "^3.0.0",
+            "@sideway/pinpoint": "^2.0.0"
+          }
         },
         "js-string-escape": {
           "version": "1.0.1",
@@ -7045,6 +7113,17 @@
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
           "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
         },
+        "simple-oauth2": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/simple-oauth2/-/simple-oauth2-4.3.0.tgz",
+          "integrity": "sha512-gjLIfy7M7WZSf3k5IZCQfEozbQwmW80zR9YMH4ph/WWG6S4U6sGhPujz8X6Hj6sZ8l7acSAxiyM4tF0vIN+E+A==",
+          "requires": {
+            "@hapi/hoek": "^9.0.4",
+            "@hapi/wreck": "^17.0.0",
+            "debug": "^4.1.1",
+            "joi": "^17.3.0"
+          }
+        },
         "sinon": {
           "version": "9.2.0",
           "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.0.tgz",
@@ -8454,6 +8533,12 @@
         "@types/node": "*"
       }
     },
+    "@types/simple-oauth2": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/simple-oauth2/-/simple-oauth2-4.1.1.tgz",
+      "integrity": "sha512-8jqhfUFb0FoCl2Od4czprB7ubM8/Fuo3tg+vQZ00zYtPcNLogGyDgm2DVfVvD3NYXK7AscKOXSaW33NHUWpNBg==",
+      "dev": true
+    },
     "@types/sizzle": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
@@ -8968,87 +9053,333 @@
       "version": "file:../etherpad-lite/src",
       "dev": true,
       "requires": {
-        "async": "^3.2.0",
-        "async-stacktrace": "0.0.2",
-        "channels": "0.0.4",
-        "cheerio": "0.22.0",
-        "clean-css": "4.2.3",
+        "async": "^3.2.1",
+        "clean-css": "^5.2.1",
         "cookie-parser": "1.4.5",
-        "ejs": "2.6.1",
-        "etherpad-require-kernel": "1.0.9",
-        "etherpad-yajsml": "0.0.2",
+        "cross-spawn": "^7.0.3",
+        "ejs": "^3.1.6",
+        "etherpad-require-kernel": "^1.0.15",
+        "etherpad-yajsml": "0.0.12",
         "express": "4.17.1",
-        "express-rate-limit": "5.1.1",
-        "express-session": "1.17.1",
+        "express-rate-limit": "5.5.0",
+        "express-session": "1.17.2",
+        "fast-deep-equal": "^3.1.3",
         "find-root": "1.1.0",
-        "formidable": "1.2.1",
-        "graceful-fs": "4.2.4",
+        "formidable": "1.2.2",
         "http-errors": "1.8.0",
-        "js-cookie": "^2.2.1",
+        "js-cookie": "^3.0.1",
+        "jsdom": "^17.0.0",
         "jsonminify": "0.4.1",
         "languages4translatewiki": "0.1.3",
         "lodash.clonedeep": "4.5.0",
-        "log4js": "0.6.35",
-        "measured-core": "1.11.2",
-        "mime-types": "^2.1.27",
-        "nodeify": "1.0.1",
-        "npm": "6.14.8",
-        "openapi-backend": "2.4.1",
-        "proxy-addr": "^2.0.6",
-        "rate-limiter-flexible": "^2.1.4",
-        "rehype": "^10.0.0",
+        "log4js": "0.6.38",
+        "measured-core": "^2.0.0",
+        "mime-types": "^2.1.33",
+        "npm": "^6.14.15",
+        "openapi-backend": "^4.2.0",
+        "proxy-addr": "^2.0.7",
+        "rate-limiter-flexible": "^2.3.1",
+        "rehype": "^11.0.0",
         "rehype-minify-whitespace": "^4.0.5",
         "request": "2.88.2",
-        "resolve": "1.1.7",
+        "resolve": "1.20.0",
         "security": "1.0.0",
-        "semver": "5.6.0",
-        "slide": "1.1.6",
+        "semver": "^7.3.5",
         "socket.io": "^2.4.1",
-        "terser": "^4.7.0",
-        "threads": "^1.4.0",
+        "terser": "^5.9.0",
+        "threads": "^1.7.0",
         "tiny-worker": "^2.3.0",
-        "tinycon": "0.0.1",
-        "ueberdb2": "^1.2.5",
-        "underscore": "1.8.3",
-        "unorm": "1.4.1"
+        "tinycon": "0.6.8",
+        "ueberdb2": "^1.4.18",
+        "underscore": "1.13.1",
+        "unorm": "1.6.0",
+        "wtfnode": "^0.9.1"
       },
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
-          "integrity": "sha512-n4YBtwQhdpLto1BaUCyAeflizmIbaloGShsPyRtFf5qdFJxfssj+GgLavczgKJFa3Bq+3St2CKcpRJdjtB4EBw==",
+          "version": "9.0.9",
+          "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+          "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
           "dev": true,
           "requires": {
-            "@jsdevtools/ono": "^7.1.0",
+            "@jsdevtools/ono": "^7.1.3",
+            "@types/json-schema": "^7.0.6",
             "call-me-maybe": "^1.0.1",
-            "js-yaml": "^3.13.1"
+            "js-yaml": "^4.1.0"
           }
         },
-        "@apidevtools/openapi-schemas": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.0.4.tgz",
-          "integrity": "sha512-ob5c4UiaMYkb24pNhvfSABShAwpREvUGCkqjiz/BX9gKZ32y/S22M+ALIHftTAuv9KsFVSpVdIDzi9ZzFh5TCA==",
-          "dev": true
-        },
-        "@apidevtools/swagger-methods": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
-          "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
-          "dev": true
-        },
-        "@apidevtools/swagger-parser": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-9.0.1.tgz",
-          "integrity": "sha512-Irqybg4dQrcHhZcxJc/UM4vO7Ksoj1Id5e+K94XUOzllqX1n47HEA50EKiXTCQbykxuJ4cYGIivjx/MRSTC5OA==",
+        "@azure/abort-controller": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.4.tgz",
+          "integrity": "sha512-lNUmDRVGpanCsiUN3NWxFTdwmdFI53xwhkTFfHDGTYk46ca7Ind3nanJc+U6Zj9Tv+9nTCWRBscWEW1DyKOpTw==",
           "dev": true,
           "requires": {
-            "@apidevtools/json-schema-ref-parser": "^8.0.0",
-            "@apidevtools/openapi-schemas": "^2.0.2",
-            "@apidevtools/swagger-methods": "^3.0.0",
-            "@jsdevtools/ono": "^7.1.0",
-            "call-me-maybe": "^1.0.1",
-            "openapi-types": "^1.3.5",
-            "z-schema": "^4.2.2"
+            "tslib": "^2.0.0"
+          }
+        },
+        "@azure/core-asynciterator-polyfill": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz",
+          "integrity": "sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg==",
+          "dev": true
+        },
+        "@azure/core-auth": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.3.2.tgz",
+          "integrity": "sha512-7CU6DmCHIZp5ZPiZ9r3J17lTKMmYsm/zGvNkjArQwPkrLlZ1TZ+EUYfGgh2X31OLMVAQCTJZW4cXHJi02EbJnA==",
+          "dev": true,
+          "requires": {
+            "@azure/abort-controller": "^1.0.0",
+            "tslib": "^2.2.0"
+          }
+        },
+        "@azure/core-client": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.4.0.tgz",
+          "integrity": "sha512-6v1pn4ubNSeI56PUgj2NLR/nfoMfkjYmrtNX0YdXrjxSajKcf/TZc/QJtTFj4wHIvYqU/Yn/g/Zb+MNhFZ5c+Q==",
+          "dev": true,
+          "requires": {
+            "@azure/abort-controller": "^1.0.0",
+            "@azure/core-asynciterator-polyfill": "^1.0.0",
+            "@azure/core-auth": "^1.3.0",
+            "@azure/core-rest-pipeline": "^1.4.0",
+            "@azure/core-tracing": "1.0.0-preview.13",
+            "@azure/logger": "^1.0.0",
+            "tslib": "^2.2.0"
+          },
+          "dependencies": {
+            "@azure/core-tracing": {
+              "version": "1.0.0-preview.13",
+              "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
+              "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
+              "dev": true,
+              "requires": {
+                "@opentelemetry/api": "^1.0.1",
+                "tslib": "^2.2.0"
+              }
+            }
+          }
+        },
+        "@azure/core-http": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-2.2.3.tgz",
+          "integrity": "sha512-xr8AeszxP418rI//W38NfJDDr0kbVAPZkURZnZ+Fle+lLWeURjDE5zNIuocA1wUPoKSP8iXc0ApW6nPtbLGswA==",
+          "dev": true,
+          "requires": {
+            "@azure/abort-controller": "^1.0.0",
+            "@azure/core-asynciterator-polyfill": "^1.0.0",
+            "@azure/core-auth": "^1.3.0",
+            "@azure/core-tracing": "1.0.0-preview.13",
+            "@azure/logger": "^1.0.0",
+            "@types/node-fetch": "^2.5.0",
+            "@types/tunnel": "^0.0.3",
+            "form-data": "^4.0.0",
+            "node-fetch": "^2.6.6",
+            "process": "^0.11.10",
+            "tough-cookie": "^4.0.0",
+            "tslib": "^2.2.0",
+            "tunnel": "^0.0.6",
+            "uuid": "^8.3.0",
+            "xml2js": "^0.4.19"
+          },
+          "dependencies": {
+            "@azure/core-tracing": {
+              "version": "1.0.0-preview.13",
+              "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
+              "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
+              "dev": true,
+              "requires": {
+                "@opentelemetry/api": "^1.0.1",
+                "tslib": "^2.2.0"
+              }
+            },
+            "form-data": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+              "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+              "dev": true,
+              "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+              }
+            },
+            "tough-cookie": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+              "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+              "dev": true,
+              "requires": {
+                "psl": "^1.1.33",
+                "punycode": "^2.1.1",
+                "universalify": "^0.1.2"
+              }
+            },
+            "uuid": {
+              "version": "8.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+              "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+              "dev": true
+            }
+          }
+        },
+        "@azure/core-lro": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.2.3.tgz",
+          "integrity": "sha512-UMdlR9NsqDCLTba3EUbRjfMF4gDmWvld196JmUjbz9WWhJ2XT00OR5MXeWiR+vmGT+ETiO4hHFCi2/eGO5YVtg==",
+          "dev": true,
+          "requires": {
+            "@azure/abort-controller": "^1.0.0",
+            "@azure/core-tracing": "1.0.0-preview.13",
+            "@azure/logger": "^1.0.0",
+            "tslib": "^2.2.0"
+          },
+          "dependencies": {
+            "@azure/core-tracing": {
+              "version": "1.0.0-preview.13",
+              "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
+              "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
+              "dev": true,
+              "requires": {
+                "@opentelemetry/api": "^1.0.1",
+                "tslib": "^2.2.0"
+              }
+            }
+          }
+        },
+        "@azure/core-paging": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.2.1.tgz",
+          "integrity": "sha512-UtH5iMlYsvg+nQYIl4UHlvvSrsBjOlRF4fs0j7mxd3rWdAStrKYrh2durOpHs5C9yZbVhsVDaisoyaf/lL1EVA==",
+          "dev": true,
+          "requires": {
+            "@azure/core-asynciterator-polyfill": "^1.0.0",
+            "tslib": "^2.2.0"
+          }
+        },
+        "@azure/core-rest-pipeline": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.4.0.tgz",
+          "integrity": "sha512-M2uL9PbvhJIEMRoUad3EnXCHWLN/i0W7D7MQJ9rnIDW7iLVCteUiegdqNa2Cr1/7he/ysEXYiwaXiHmfack/6g==",
+          "dev": true,
+          "requires": {
+            "@azure/abort-controller": "^1.0.0",
+            "@azure/core-auth": "^1.3.0",
+            "@azure/core-tracing": "1.0.0-preview.13",
+            "@azure/logger": "^1.0.0",
+            "form-data": "^4.0.0",
+            "http-proxy-agent": "^4.0.1",
+            "https-proxy-agent": "^5.0.0",
+            "tslib": "^2.2.0",
+            "uuid": "^8.3.0"
+          },
+          "dependencies": {
+            "@azure/core-tracing": {
+              "version": "1.0.0-preview.13",
+              "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
+              "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
+              "dev": true,
+              "requires": {
+                "@opentelemetry/api": "^1.0.1",
+                "tslib": "^2.2.0"
+              }
+            },
+            "form-data": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+              "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+              "dev": true,
+              "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+              }
+            },
+            "uuid": {
+              "version": "8.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+              "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+              "dev": true
+            }
+          }
+        },
+        "@azure/core-tracing": {
+          "version": "1.0.0-preview.12",
+          "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.12.tgz",
+          "integrity": "sha512-nvo2Wc4EKZGN6eFu9n3U7OXmASmL8VxoPIH7xaD6OlQqi44bouF0YIi9ID5rEsKLiAU59IYx6M297nqWVMWPDg==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/api": "^1.0.0",
+            "tslib": "^2.2.0"
+          }
+        },
+        "@azure/identity": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-1.5.2.tgz",
+          "integrity": "sha512-vqyeRbd2i0h9F4mqW5JbkP1xfabqKQ21l/81osKhpOQ2LtwaJW6nw4+0PsVYnxcbPHFCIZt6EWAk74a3OGYZJA==",
+          "dev": true,
+          "requires": {
+            "@azure/core-auth": "^1.3.0",
+            "@azure/core-client": "^1.0.0",
+            "@azure/core-rest-pipeline": "^1.1.0",
+            "@azure/core-tracing": "1.0.0-preview.12",
+            "@azure/logger": "^1.0.0",
+            "@azure/msal-node": "1.0.0-beta.6",
+            "@types/stoppable": "^1.1.0",
+            "axios": "^0.21.1",
+            "events": "^3.0.0",
+            "jws": "^4.0.0",
+            "keytar": "^7.3.0",
+            "msal": "^1.0.2",
+            "open": "^7.0.0",
+            "qs": "^6.7.0",
+            "stoppable": "^1.1.0",
+            "tslib": "^2.0.0",
+            "uuid": "^8.3.0"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "8.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+              "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+              "dev": true
+            }
+          }
+        },
+        "@azure/keyvault-keys": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/@azure/keyvault-keys/-/keyvault-keys-4.3.0.tgz",
+          "integrity": "sha512-OEosl0/rE/mKD5Ji9KaQN7UH+yQnV5MS0MRhGqQIiJrG+qAvAla0MYudJzv3XvBlplpGk0+MVgyL9H3KX/UAwQ==",
+          "dev": true,
+          "requires": {
+            "@azure/abort-controller": "^1.0.0",
+            "@azure/core-http": "^2.0.0",
+            "@azure/core-lro": "^2.0.0",
+            "@azure/core-paging": "^1.1.1",
+            "@azure/core-tracing": "1.0.0-preview.13",
+            "@azure/logger": "^1.0.0",
+            "tslib": "^2.2.0"
+          },
+          "dependencies": {
+            "@azure/core-tracing": {
+              "version": "1.0.0-preview.13",
+              "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
+              "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
+              "dev": true,
+              "requires": {
+                "@opentelemetry/api": "^1.0.1",
+                "tslib": "^2.2.0"
+              }
+            }
+          }
+        },
+        "@azure/logger": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.3.tgz",
+          "integrity": "sha512-aK4s3Xxjrx3daZr3VylxejK3vG5ExXck5WOHDJ8in/k9AqlfIyFMMT1uG7u8mNjX+QRILTIn0/Xgschfh/dQ9g==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.2.0"
           }
         },
         "@azure/ms-rest-azure-env": {
@@ -9058,20 +9389,19 @@
           "dev": true
         },
         "@azure/ms-rest-js": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.1.0.tgz",
-          "integrity": "sha512-4BXLVImYRt+jcUmEJ5LUWglI8RBNVQndY6IcyvQ4U8O4kIXdmlRz3cJdA/RpXf5rKT38KOoTO2T6Z1f6Z1HDBg==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.6.0.tgz",
+          "integrity": "sha512-4C5FCtvEzWudblB+h92/TYYPiq7tuElX8icVYToxOdggnYqeec4Se14mjse5miInKtZahiFHdl8lZA/jziEc5g==",
           "dev": true,
           "requires": {
-            "@types/node-fetch": "^2.3.7",
-            "@types/tunnel": "0.0.1",
+            "@azure/core-auth": "^1.1.4",
             "abort-controller": "^3.0.0",
             "form-data": "^2.5.0",
             "node-fetch": "^2.6.0",
             "tough-cookie": "^3.0.1",
             "tslib": "^1.10.0",
             "tunnel": "0.0.6",
-            "uuid": "^3.3.2",
+            "uuid": "^8.3.2",
             "xml2js": "^0.4.19"
           },
           "dependencies": {
@@ -9096,18 +9426,76 @@
                 "psl": "^1.1.28",
                 "punycode": "^2.1.1"
               }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+              "dev": true
+            },
+            "uuid": {
+              "version": "8.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+              "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+              "dev": true
             }
           }
         },
         "@azure/ms-rest-nodeauth": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/@azure/ms-rest-nodeauth/-/ms-rest-nodeauth-3.0.6.tgz",
-          "integrity": "sha512-2twuzsXHdKMzEFI2+Sr82o6yS4ppNGZceYwil8PFo+rJxOZIoBm9e0//YC+dKilV/3F+6K/HuW8LdskDrJEQWA==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@azure/ms-rest-nodeauth/-/ms-rest-nodeauth-3.1.1.tgz",
+          "integrity": "sha512-UA/8dgLy3+ZiwJjAZHxL4MUB14fFQPkaAOZ94jsTW/Z6WmoOeny2+cLk0+dyIX/iH6qSrEWKwbStEeB970B9pA==",
           "dev": true,
           "requires": {
             "@azure/ms-rest-azure-env": "^2.0.0",
             "@azure/ms-rest-js": "^2.0.4",
-            "adal-node": "^0.1.28"
+            "adal-node": "^0.2.2"
+          }
+        },
+        "@azure/msal-common": {
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-4.5.1.tgz",
+          "integrity": "sha512-/i5dXM+QAtO+6atYd5oHGBAx48EGSISkXNXViheliOQe+SIFMDo3gSq3lL54W0suOSAsVPws3XnTaIHlla0PIQ==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.3.3",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+              "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+              "dev": true,
+              "requires": {
+                "ms": "2.1.2"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
+        },
+        "@azure/msal-node": {
+          "version": "1.0.0-beta.6",
+          "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.0.0-beta.6.tgz",
+          "integrity": "sha512-ZQI11Uz1j0HJohb9JZLRD8z0moVcPks1AFW4Q/Gcl67+QvH4aKEJti7fjCcipEEZYb/qzLSO8U6IZgPYytsiJQ==",
+          "dev": true,
+          "requires": {
+            "@azure/msal-common": "^4.0.0",
+            "axios": "^0.21.1",
+            "jsonwebtoken": "^8.5.1",
+            "uuid": "^8.3.0"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "8.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+              "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+              "dev": true
+            }
           }
         },
         "@babel/code-frame": {
@@ -9136,7 +9524,6 @@
             "gensync": "^1.0.0-beta.1",
             "json5": "^2.1.2",
             "lodash": "^4.17.19",
-            "semver": "^5.4.1",
             "source-map": "^0.5.0"
           },
           "dependencies": {
@@ -9387,7 +9774,6 @@
             "globals": "^12.1.0",
             "ignore": "^4.0.6",
             "import-fresh": "^3.2.1",
-            "js-yaml": "^3.13.1",
             "lodash": "^4.17.20",
             "minimatch": "^3.0.4",
             "strip-json-comments": "^3.1.1"
@@ -9421,7 +9807,6 @@
             "camelcase": "^5.3.1",
             "find-up": "^4.1.0",
             "get-package-type": "^0.1.0",
-            "js-yaml": "^3.13.1",
             "resolve-from": "^5.0.0"
           },
           "dependencies": {
@@ -9489,9 +9874,9 @@
           },
           "dependencies": {
             "debug": {
-              "version": "4.3.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-              "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+              "version": "4.3.3",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+              "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
               "dev": true,
               "requires": {
                 "ms": "2.1.2"
@@ -9509,6 +9894,132 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
           "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+          "dev": true
+        },
+        "@mapbox/node-pre-gyp": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.8.tgz",
+          "integrity": "sha512-CMGKi28CF+qlbXh26hDe6NxCd7amqeAzEqnS6IHeO6LoaKyM/n+Xw3HT1COdq8cuioOdlKdqn/hCmqPUOMOywg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "https-proxy-agent": "^5.0.0",
+            "make-dir": "^3.1.0",
+            "node-fetch": "^2.6.5",
+            "nopt": "^5.0.0",
+            "npmlog": "^5.0.1",
+            "rimraf": "^3.0.2",
+            "semver": "^7.3.5",
+            "tar": "^6.1.11"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+              "dev": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+              "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^3.6.0"
+              }
+            },
+            "gauge": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+              "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3 || ^2.0.0",
+                "color-support": "^1.1.2",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.1",
+                "object-assign": "^4.1.1",
+                "signal-exit": "^3.0.0",
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1",
+                "wide-align": "^1.1.2"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+              "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+              "dev": true,
+              "optional": true
+            },
+            "npmlog": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+              "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "^2.0.0",
+                "console-control-strings": "^1.1.0",
+                "gauge": "^3.0.0",
+                "set-blocking": "^2.0.0"
+              }
+            },
+            "readable-stream": {
+              "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+              "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            },
+            "string-width": {
+              "version": "4.2.3",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+              "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+              "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.2.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "6.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+              "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ansi-regex": "^5.0.1"
+              }
+            }
+          }
+        },
+        "@opentelemetry/api": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.4.tgz",
+          "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog==",
           "dev": true
         },
         "@sinonjs/commons": {
@@ -9533,7 +10044,6 @@
           "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
           "requires": {
             "@sinonjs/commons": "^1.6.0",
-            "lodash.get": "^4.4.2",
             "type-detect": "^4.0.8"
           }
         },
@@ -9542,10 +10052,31 @@
           "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
           "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
         },
-        "@types/caseless": {
-          "version": "0.12.2",
-          "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-          "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+        "@tediousjs/connection-string": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@tediousjs/connection-string/-/connection-string-0.3.0.tgz",
+          "integrity": "sha512-d/keJiNKfpHo+GmSB8QcsAwBx8h+V1UbdozA5TD+eSLXprNY53JAYub47J9evsSKWDdNG5uVj0FiMozLKuzowQ==",
+          "dev": true
+        },
+        "@tootallnate/once": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+          "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+          "dev": true
+        },
+        "@types/hast": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
+          "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "*"
+          }
+        },
+        "@types/json-schema": {
+          "version": "7.0.9",
+          "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+          "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
           "dev": true
         },
         "@types/long": {
@@ -9555,15 +10086,15 @@
           "dev": true
         },
         "@types/node": {
-          "version": "14.14.22",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.22.tgz",
-          "integrity": "sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw==",
+          "version": "17.0.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
+          "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
           "dev": true
         },
         "@types/node-fetch": {
-          "version": "2.5.8",
-          "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.8.tgz",
-          "integrity": "sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==",
+          "version": "2.5.12",
+          "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
+          "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
           "dev": true,
           "requires": {
             "@types/node": "*",
@@ -9571,9 +10102,9 @@
           },
           "dependencies": {
             "form-data": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-              "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+              "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
               "dev": true,
               "requires": {
                 "asynckit": "^0.4.0",
@@ -9583,50 +10114,52 @@
             }
           }
         },
-        "@types/request": {
-          "version": "2.48.5",
-          "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
-          "integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
+        "@types/parse5": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
+          "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==",
+          "dev": true
+        },
+        "@types/stoppable": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@types/stoppable/-/stoppable-1.1.1.tgz",
+          "integrity": "sha512-b8N+fCADRIYYrGZOcmOR8ZNBOqhktWTB/bMUl5LvGtT201QKJZOOH5UsFyI3qtteM6ZAJbJqZoBcLqqxKIwjhw==",
           "dev": true,
           "requires": {
-            "@types/caseless": "*",
-            "@types/node": "*",
-            "@types/tough-cookie": "*",
-            "form-data": "^2.5.0"
-          },
-          "dependencies": {
-            "form-data": {
-              "version": "2.5.1",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-              "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-              "dev": true,
-              "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
-              }
-            }
+            "@types/node": "*"
           }
         },
         "@types/tough-cookie": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
-          "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
+          "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==",
           "dev": true
         },
         "@types/tunnel": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
-          "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.3.tgz",
+          "integrity": "sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==",
           "dev": true,
           "requires": {
             "@types/node": "*"
           }
         },
         "@types/unist": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
-          "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
+          "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
+          "dev": true
+        },
+        "@xmldom/xmldom": {
+          "version": "0.7.5",
+          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
+          "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
+          "dev": true
+        },
+        "abab": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+          "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
           "dev": true
         },
         "abbrev": {
@@ -9660,46 +10193,100 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
         },
+        "acorn-globals": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+          "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.1.1",
+            "acorn-walk": "^7.1.1"
+          }
+        },
         "acorn-jsx": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
           "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng=="
         },
+        "acorn-walk": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+          "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+          "dev": true
+        },
         "adal-node": {
-          "version": "0.1.28",
-          "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.1.28.tgz",
-          "integrity": "sha1-RoxLs+u9lrEnBmn0ucuk4AZepIU=",
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.3.tgz",
+          "integrity": "sha512-gMKr8RuYEYvsj7jyfCv/4BfKToQThz20SP71N3AtFn3ia3yAR8Qt2T3aVQhuJzunWs2b38ZsQV0qsZPdwZr7VQ==",
           "dev": true,
           "requires": {
-            "@types/node": "^8.0.47",
-            "async": ">=0.6.0",
+            "@xmldom/xmldom": "^0.7.0",
+            "async": "^2.6.3",
+            "axios": "^0.21.1",
             "date-utils": "*",
             "jws": "3.x.x",
-            "request": ">= 2.52.0",
             "underscore": ">= 1.3.1",
             "uuid": "^3.1.0",
-            "xmldom": ">= 0.1.x",
             "xpath.js": "~1.1.0"
           },
           "dependencies": {
-            "@types/node": {
-              "version": "8.10.66",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
-              "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
-              "dev": true
+            "async": {
+              "version": "2.6.3",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+              "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+              "dev": true,
+              "requires": {
+                "lodash": "^4.17.14"
+              }
+            },
+            "jws": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+              "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+              "dev": true,
+              "requires": {
+                "jwa": "^1.4.1",
+                "safe-buffer": "^5.0.1"
+              }
             }
           }
         },
         "adm-zip": {
-          "version": "0.4.16",
-          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
-          "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==",
+          "version": "0.5.9",
+          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
+          "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==",
           "dev": true
         },
         "after": {
           "version": "0.8.2",
           "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
           "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+        },
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "dev": true,
+          "requires": {
+            "debug": "4"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.3.3",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+              "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+              "dev": true,
+              "requires": {
+                "ms": "2.1.2"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
         },
         "agentkeepalive": {
           "version": "3.5.2",
@@ -9730,6 +10317,35 @@
             "uri-js": "^4.2.2"
           }
         },
+        "ajv-formats": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+          "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+          "dev": true,
+          "requires": {
+            "ajv": "^8.0.0"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "8.8.2",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+              "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+              "dev": true,
+              "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.2.2"
+              }
+            },
+            "json-schema-traverse": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+              "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+              "dev": true
+            }
+          }
+        },
         "ansi-colors": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -9738,13 +10354,17 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
         },
         "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
         },
         "anymatch": {
           "version": "3.1.1",
@@ -9779,7 +10399,6 @@
             "async": "^2.6.3",
             "buffer-crc32": "^0.2.1",
             "glob": "^7.1.4",
-            "readable-stream": "^3.4.0",
             "tar-stream": "^2.1.0",
             "zip-stream": "^2.1.2"
           },
@@ -9851,9 +10470,9 @@
           "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
         },
         "are-we-there-yet": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+          "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -9904,12 +10523,10 @@
           }
         },
         "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
         },
         "array-flatten": {
           "version": "1.1.1",
@@ -9941,15 +10558,14 @@
           "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
         },
         "async": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+          "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
         },
         "async-stacktrace": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/async-stacktrace/-/async-stacktrace-0.0.2.tgz",
-          "integrity": "sha1-i7uXh+OzjINscpp+nXwIYw210e8=",
-          "dev": true
+          "integrity": "sha1-i7uXh+OzjINscpp+nXwIYw210e8="
         },
         "asynckit": {
           "version": "0.4.0",
@@ -9966,6 +10582,25 @@
           "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
           "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
         },
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        },
+        "axios-cookiejar-support": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-1.0.1.tgz",
+          "integrity": "sha512-IZJxnAJ99XxiLqNeMOqrPbfR7fRyIfaoSLdPUf4AMQEGkH8URs0ghJK/xtqBsD+KsSr3pKl4DEQjCn834pHMig==",
+          "dev": true,
+          "requires": {
+            "is-redirect": "^1.0.0",
+            "pify": "^5.0.0"
+          }
+        },
         "backo2": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
@@ -9978,9 +10613,9 @@
           "dev": true
         },
         "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
         "base64-arraybuffer": {
           "version": "0.1.4",
@@ -10092,16 +10727,6 @@
           "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
           "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
         },
-        "block-stream": {
-          "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "inherits": "~2.0.0"
-          }
-        },
         "bluebird": {
           "version": "2.11.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
@@ -10150,8 +10775,7 @@
         "boolbase": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-          "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-          "dev": true
+          "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
         },
         "brace-expansion": {
           "version": "1.1.11",
@@ -10170,10 +10794,10 @@
             "fill-range": "^7.0.1"
           }
         },
-        "browser-request": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
-          "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc=",
+        "browser-process-hrtime": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+          "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
           "dev": true
         },
         "browser-stdout": {
@@ -10182,9 +10806,9 @@
           "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
         },
         "bson": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==",
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+          "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
           "dev": true
         },
         "buffer": {
@@ -10208,9 +10832,9 @@
           "dev": true
         },
         "buffer-from": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+          "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
           "dev": true
         },
         "buffer-writer": {
@@ -10267,14 +10891,14 @@
           "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "cassandra-driver": {
-          "version": "4.6.1",
-          "resolved": "https://registry.npmjs.org/cassandra-driver/-/cassandra-driver-4.6.1.tgz",
-          "integrity": "sha512-Vk0kUHlMV4vFXRPwRpKnCZEEMZkp9/RucBDB7gpaUmn9sCusKzzUzVkXeusTxKSoGuIgLJJ7YBiFJdXOctUS7A==",
+          "version": "4.6.3",
+          "resolved": "https://registry.npmjs.org/cassandra-driver/-/cassandra-driver-4.6.3.tgz",
+          "integrity": "sha512-npW670TXjTHrdb15LUFN01wssb9vvz6SuNYcppesoKcUXx3Q29nXVhRtnvsnkG0BaSnDGvCCR4udrzYLsbh+sg==",
           "dev": true,
           "requires": {
             "@types/long": "^4.0.0",
             "@types/node": ">=8",
-            "adm-zip": "^0.4.13",
+            "adm-zip": "^0.5.3",
             "long": "^2.2.0"
           }
         },
@@ -10285,23 +10909,15 @@
           "dev": true
         },
         "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
-        },
-        "channels": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/channels/-/channels-0.0.4.tgz",
-          "integrity": "sha1-G+4yPt6hUrue8E9BvG5rD1lIqUE=",
-          "dev": true
         },
         "character-entities-html4": {
           "version": "1.1.4",
@@ -10319,7 +10935,6 @@
           "version": "0.22.0",
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
           "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
-          "dev": true,
           "requires": {
             "css-select": "~1.2.0",
             "dom-serializer": "~0.1.0",
@@ -10362,9 +10977,9 @@
           "optional": true
         },
         "clean-css": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
-          "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.2.2.tgz",
+          "integrity": "sha512-/eR8ru5zyxKzpBLv9YZvMXgTSSQn7AdkMItMYynsFgGwTveCRVam9IUPFloE85B4vAIj05IuKmmEoV7/AQjT0w==",
           "dev": true,
           "requires": {
             "source-map": "~0.6.0"
@@ -10420,38 +11035,12 @@
             }
           }
         },
-        "cloudant-follow": {
-          "version": "0.18.2",
-          "resolved": "https://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.18.2.tgz",
-          "integrity": "sha512-qu/AmKxDqJds+UmT77+0NbM7Yab2K3w0qSeJRzsq5dRWJTEJdWeb+XpG4OpKuTE9RKOa/Awn2gR3TTnvNr3TeA==",
-          "dev": true,
-          "requires": {
-            "browser-request": "~0.3.0",
-            "debug": "^4.0.1",
-            "request": "^2.88.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "4.3.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-              "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-              "dev": true,
-              "requires": {
-                "ms": "2.1.2"
-              }
-            },
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-              "dev": true
-            }
-          }
-        },
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true,
+          "optional": true
         },
         "color-convert": {
           "version": "1.9.3",
@@ -10465,6 +11054,13 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "color-support": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+          "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.8",
@@ -10646,8 +11242,7 @@
           "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
           "integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
           "requires": {
-            "crc": "^3.4.4",
-            "readable-stream": "^3.4.0"
+            "crc": "^3.4.4"
           }
         },
         "cross-spawn": {
@@ -10674,7 +11269,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
           "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-          "dev": true,
           "requires": {
             "boolbase": "~1.0.0",
             "css-what": "2.1",
@@ -10685,8 +11279,30 @@
         "css-what": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
-          "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+          "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+        },
+        "cssom": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+          "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
           "dev": true
+        },
+        "cssstyle": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+          "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+          "dev": true,
+          "requires": {
+            "cssom": "~0.3.6"
+          },
+          "dependencies": {
+            "cssom": {
+              "version": "0.3.8",
+              "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+              "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+              "dev": true
+            }
+          }
         },
         "dashdash": {
           "version": "1.14.1",
@@ -10694,6 +11310,41 @@
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "requires": {
             "assert-plus": "^1.0.0"
+          }
+        },
+        "data-urls": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.1.tgz",
+          "integrity": "sha512-Ds554NeT5Gennfoo9KN50Vh6tpgtvYEwraYjejXnyTpu1C7oXKxdFk75REooENHE8ndTVOJuv+BEs4/J/xcozw==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.3",
+            "whatwg-mimetype": "^3.0.0",
+            "whatwg-url": "^10.0.0"
+          },
+          "dependencies": {
+            "webidl-conversions": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+              "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+              "dev": true
+            },
+            "whatwg-mimetype": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+              "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+              "dev": true
+            },
+            "whatwg-url": {
+              "version": "10.0.0",
+              "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-10.0.0.tgz",
+              "integrity": "sha512-CLxxCmdUby142H5FZzn4D8ikO1cmypvXVQktsgosNy4a4BHrDHeciBBGZhb0bNoR5/MltoCatso+vFjjGx8t0w==",
+              "dev": true,
+              "requires": {
+                "tr46": "^3.0.0",
+                "webidl-conversions": "^7.0.0"
+              }
+            }
           }
         },
         "date-utils": {
@@ -10715,6 +11366,22 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+        },
+        "decimal.js": {
+          "version": "10.3.1",
+          "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+          "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
+          "dev": true
+        },
+        "decompress-response": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "mimic-response": "^2.0.0"
+          }
         },
         "deep-extend": {
           "version": "0.6.0",
@@ -10757,9 +11424,9 @@
           "optional": true
         },
         "denque": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
-          "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==",
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+          "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
           "dev": true
         },
         "depd": {
@@ -10787,9 +11454,9 @@
           "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
         },
         "dirty": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/dirty/-/dirty-1.1.0.tgz",
-          "integrity": "sha1-cO3SuZlUHcmXT9Ooy9DGcP4jYHg=",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/dirty/-/dirty-1.1.3.tgz",
+          "integrity": "sha512-PlnV9+KeJ6bh8o5qQZqRnD80Wegijyr47dpwxCIuJ6SzwJ6/deO+NRTEnq/mubIYtBvBBgWznlE6dZ+nQsS/og==",
           "dev": true
         },
         "doctrine": {
@@ -10804,7 +11471,6 @@
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
           "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
-          "dev": true,
           "requires": {
             "domelementtype": "^1.3.0",
             "entities": "^1.1.1"
@@ -10813,14 +11479,29 @@
         "domelementtype": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-          "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-          "dev": true
+          "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+        },
+        "domexception": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+          "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+          "dev": true,
+          "requires": {
+            "webidl-conversions": "^5.0.0"
+          },
+          "dependencies": {
+            "webidl-conversions": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+              "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+              "dev": true
+            }
+          }
         },
         "domhandler": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
           "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-          "dev": true,
           "requires": {
             "domelementtype": "1"
           }
@@ -10829,7 +11510,6 @@
           "version": "1.5.1",
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
           "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-          "dev": true,
           "requires": {
             "dom-serializer": "0",
             "domelementtype": "1"
@@ -10860,10 +11540,13 @@
           "dev": true
         },
         "ejs": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
-          "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
-          "dev": true
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
+          "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+          "dev": true,
+          "requires": {
+            "jake": "^10.6.1"
+          }
         },
         "elasticsearch": {
           "version": "16.7.2",
@@ -10874,6 +11557,33 @@
             "agentkeepalive": "^3.4.1",
             "chalk": "^1.0.0",
             "lodash": "^4.17.10"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
           }
         },
         "emoji-regex": {
@@ -10983,14 +11693,14 @@
         "entities": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-          "dev": true
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
         },
-        "errs": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/errs/-/errs-0.3.2.tgz",
-          "integrity": "sha1-eYCZstvTfKK8dJ5TinwTB9C1BJk=",
-          "dev": true
+        "env-paths": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+          "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+          "dev": true,
+          "optional": true
         },
         "es-abstract": {
           "version": "1.18.0-next.2",
@@ -11052,6 +11762,66 @@
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
+        "escodegen": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+          "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+          "dev": true,
+          "requires": {
+            "esprima": "^4.0.1",
+            "estraverse": "^5.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "5.3.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+              "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+              "dev": true
+            },
+            "levn": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+              "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+              "dev": true,
+              "requires": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+              }
+            },
+            "optionator": {
+              "version": "0.8.3",
+              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+              "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+              "dev": true,
+              "requires": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.6",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "word-wrap": "~1.2.3"
+              }
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+              "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+              "dev": true
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+              "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+              "dev": true,
+              "requires": {
+                "prelude-ls": "~1.1.2"
+              }
+            }
+          }
+        },
         "eslint": {
           "version": "7.18.0",
           "resolved": false,
@@ -11079,7 +11849,6 @@
             "import-fresh": "^3.0.0",
             "imurmurhash": "^0.1.4",
             "is-glob": "^4.0.0",
-            "js-yaml": "^3.13.1",
             "json-stable-stringify-without-jsonify": "^1.0.1",
             "levn": "^0.4.1",
             "lodash": "^4.17.20",
@@ -11196,7 +11965,7 @@
         },
         "eslint-plugin-eslint-comments": {
           "version": "3.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
           "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
           "requires": {
             "escape-string-regexp": "^1.0.5",
@@ -11221,7 +11990,7 @@
         },
         "eslint-plugin-node": {
           "version": "11.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
           "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
           "requires": {
             "eslint-plugin-es": "^3.0.0",
@@ -11242,7 +12011,8 @@
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
               "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
               "requires": {
-                "is-core-module": "^2.1.0"
+                "is-core-module": "^2.1.0",
+                "path-parse": "^1.0.6"
               }
             },
             "semver": {
@@ -11383,22 +12153,38 @@
           }
         },
         "etherpad-require-kernel": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/etherpad-require-kernel/-/etherpad-require-kernel-1.0.9.tgz",
-          "integrity": "sha1-7Y8E6f0szsOgBVu20t/p2ZkS5+I=",
+          "version": "1.0.15",
+          "resolved": "https://registry.npmjs.org/etherpad-require-kernel/-/etherpad-require-kernel-1.0.15.tgz",
+          "integrity": "sha512-t8Z950sCfgS4ssex6SHhb3Ni8BQL0XdvZhMQWWDLhSWttyHgf+zPSMglBODyAUGh8mBX0XwGK7hpICGBHsvSGQ==",
           "dev": true
         },
         "etherpad-yajsml": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/etherpad-yajsml/-/etherpad-yajsml-0.0.2.tgz",
-          "integrity": "sha1-HCTSaLCUduY30EnN2xxt+McptG4=",
-          "dev": true
+          "version": "0.0.12",
+          "resolved": "https://registry.npmjs.org/etherpad-yajsml/-/etherpad-yajsml-0.0.12.tgz",
+          "integrity": "sha512-lVCqsZYpFsuIz417h+O83I7eadNXJ3MnQavriFa52/KTwj6xPAzEYr0PvH7KTxcqyAFtW7ItoTNVXe2h7zGxlw==",
+          "dev": true,
+          "requires": {
+            "mime": "^1.6.0"
+          }
         },
         "event-target-shim": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
           "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
           "dev": true
+        },
+        "events": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+          "dev": true
+        },
+        "expand-template": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+          "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+          "dev": true,
+          "optional": true
         },
         "express": {
           "version": "4.17.1",
@@ -11447,37 +12233,37 @@
           }
         },
         "express-rate-limit": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.1.1.tgz",
-          "integrity": "sha512-puA1zcCx/quwWUOU6pT6daCt6t7SweD9wKChKhb+KSgFMKRwS81C224hiSAUANw/gnSHiwEhgozM/2ezEBZPeA==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.5.0.tgz",
+          "integrity": "sha512-/1mrKggjXMxd1/ghPub5N3d36u5VlK8KjbQFQLxYub09BWSSgSXMQbXgFiIW0BYxjM49YCj8bkihONZR2U4+mQ==",
           "dev": true
         },
         "express-session": {
-          "version": "1.17.1",
-          "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.1.tgz",
-          "integrity": "sha512-UbHwgqjxQZJiWRTMyhvWGvjBQduGCSBDhhZXYenziMFjxst5rMV+aJZ6hKPHZnPyHGsrqRICxtX8jtEbm/z36Q==",
+          "version": "1.17.2",
+          "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.2.tgz",
+          "integrity": "sha512-mPcYcLA0lvh7D4Oqr5aNJFMtBMKPLl++OKKxkHzZ0U0oDq1rpKBnkR5f5vCHR26VeArlTOEF9td4x5IjICksRQ==",
           "dev": true,
           "requires": {
-            "cookie": "0.4.0",
+            "cookie": "0.4.1",
             "cookie-signature": "1.0.6",
             "debug": "2.6.9",
             "depd": "~2.0.0",
             "on-headers": "~1.0.2",
             "parseurl": "~1.3.3",
-            "safe-buffer": "5.2.0",
+            "safe-buffer": "5.2.1",
             "uid-safe": "~2.1.5"
           },
           "dependencies": {
+            "cookie": {
+              "version": "0.4.1",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+              "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+              "dev": true
+            },
             "depd": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
               "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-              "dev": true
-            },
-            "safe-buffer": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-              "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
               "dev": true
             }
           }
@@ -11513,6 +12299,15 @@
           "integrity": "sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==",
           "requires": {
             "flat-cache": "^3.0.4"
+          }
+        },
+        "filelist": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
+          "integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
+          "dev": true,
+          "requires": {
+            "minimatch": "^3.0.4"
           }
         },
         "fill-range": {
@@ -11594,6 +12389,12 @@
           "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
           "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA=="
         },
+        "follow-redirects": {
+          "version": "1.14.7",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+          "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+          "dev": true
+        },
         "foreground-child": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
@@ -11619,14 +12420,14 @@
           }
         },
         "formidable": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
-          "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+          "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
         },
         "forwarded": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-          "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+          "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
           "dev": true
         },
         "fresh": {
@@ -11646,13 +12447,13 @@
           "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
         },
         "fs-minipass": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.6.0"
+            "minipass": "^3.0.0"
           }
         },
         "fs.realpath": {
@@ -11665,19 +12466,6 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
           "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
           "optional": true
-        },
-        "fstream": {
-          "version": "1.0.12",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-          "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
-          }
         },
         "function-bind": {
           "version": "1.1.1",
@@ -11739,10 +12527,17 @@
             "assert-plus": "^1.0.0"
           }
         },
+        "github-from-package": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+          "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+          "dev": true,
+          "optional": true
+        },
         "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -11769,9 +12564,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+          "version": "4.2.9",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+          "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
         },
         "growl": {
           "version": "1.10.5",
@@ -11865,16 +12660,17 @@
           }
         },
         "hast-util-from-parse5": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.3.tgz",
-          "integrity": "sha512-gOc8UB99F6eWVWFtM9jUikjN7QkWxB3nY0df5Z0Zq1/Nkwl5V4hAAsl0tmwlgWl/1shlTF8DnNYLO8X6wRV9pA==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-6.0.1.tgz",
+          "integrity": "sha512-jeJUWiN5pSxW12Rh01smtVkZgZr33wBokLzKLwinYOUfSzm1Nl/c3GUGebDyOKjdsRgMvoVbV0VpAcpjF4NrJA==",
           "dev": true,
           "requires": {
-            "ccount": "^1.0.3",
-            "hastscript": "^5.0.0",
+            "@types/parse5": "^5.0.0",
+            "hastscript": "^6.0.0",
             "property-information": "^5.0.0",
-            "web-namespaces": "^1.1.2",
-            "xtend": "^4.0.1"
+            "vfile": "^4.0.0",
+            "vfile-location": "^3.2.0",
+            "web-namespaces": "^1.0.0"
           }
         },
         "hast-util-is-element": {
@@ -11890,21 +12686,21 @@
           "dev": true
         },
         "hast-util-to-html": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-6.1.0.tgz",
-          "integrity": "sha512-IlC+LG2HGv0Y8js3wqdhg9O2sO4iVpRDbHOPwXd7qgeagpGsnY49i8yyazwqS35RA35WCzrBQE/n0M6GG/ewxA==",
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-7.1.3.tgz",
+          "integrity": "sha512-yk2+1p3EJTEE9ZEUkgHsUSVhIpCsL/bvT8E5GzmWc+N1Po5gBw+0F8bo7dpxXR0nu0bQVxVZGX2lBGF21CmeDw==",
           "dev": true,
           "requires": {
             "ccount": "^1.0.0",
-            "comma-separated-tokens": "^1.0.1",
+            "comma-separated-tokens": "^1.0.0",
             "hast-util-is-element": "^1.0.0",
             "hast-util-whitespace": "^1.0.0",
             "html-void-elements": "^1.0.0",
-            "property-information": "^5.2.0",
+            "property-information": "^5.0.0",
             "space-separated-tokens": "^1.0.0",
-            "stringify-entities": "^2.0.0",
-            "unist-util-is": "^3.0.0",
-            "xtend": "^4.0.1"
+            "stringify-entities": "^3.0.1",
+            "unist-util-is": "^4.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "hast-util-whitespace": {
@@ -11914,11 +12710,12 @@
           "dev": true
         },
         "hastscript": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
-          "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
+          "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
           "dev": true,
           "requires": {
+            "@types/hast": "^2.0.0",
             "comma-separated-tokens": "^1.0.0",
             "hast-util-parse-selector": "^2.0.0",
             "property-information": "^5.0.0",
@@ -11929,6 +12726,15 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
           "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+        },
+        "html-encoding-sniffer": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+          "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-encoding": "^1.0.5"
+          }
         },
         "html-escaper": {
           "version": "2.0.2",
@@ -11945,14 +12751,12 @@
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
           "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-          "dev": true,
           "requires": {
             "domelementtype": "^1.3.1",
             "domhandler": "^2.3.0",
             "domutils": "^1.5.1",
             "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^3.1.1"
+            "inherits": "^2.0.1"
           }
         },
         "http-errors": {
@@ -11976,6 +12780,34 @@
             }
           }
         },
+        "http-proxy-agent": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+          "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+          "dev": true,
+          "requires": {
+            "@tootallnate/once": "1",
+            "agent-base": "6",
+            "debug": "4"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.3.3",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+              "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+              "dev": true,
+              "requires": {
+                "ms": "2.1.2"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
+        },
         "http-signature": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -11984,6 +12816,33 @@
             "assert-plus": "^1.0.0",
             "jsprim": "^1.2.2",
             "sshpk": "^1.7.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "dev": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.3.3",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+              "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+              "dev": true,
+              "requires": {
+                "ms": "2.1.2"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
           }
         },
         "humanize-ms": {
@@ -12013,16 +12872,6 @@
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
-        },
-        "ignore-walk": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-          "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
         },
         "import-fresh": {
           "version": "3.3.0",
@@ -12088,22 +12937,6 @@
           "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
           "dev": true
         },
-        "is-alphabetical": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-          "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-          "dev": true
-        },
-        "is-alphanumerical": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
-          "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-          "dev": true,
-          "requires": {
-            "is-alphabetical": "^1.0.0",
-            "is-decimal": "^1.0.0"
-          }
-        },
         "is-binary-path": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -12135,10 +12968,10 @@
           "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
           "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
         },
-        "is-decimal": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-          "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+        "is-docker": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+          "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
           "dev": true
         },
         "is-extglob": {
@@ -12150,6 +12983,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -12162,12 +12997,6 @@
             "is-extglob": "^2.1.1"
           }
         },
-        "is-hexadecimal": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-          "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-          "dev": true
-        },
         "is-negative-zero": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
@@ -12179,13 +13008,10 @@
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
         },
         "is-observable": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
-          "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-          "dev": true,
-          "requires": {
-            "symbol-observable": "^1.1.0"
-          }
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.1.0.tgz",
+          "integrity": "sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw==",
+          "dev": true
         },
         "is-plain-obj": {
           "version": "2.1.0",
@@ -12193,10 +13019,21 @@
           "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
           "dev": true
         },
+        "is-potential-custom-element-name": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+          "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+          "dev": true
+        },
         "is-promise": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
-          "integrity": "sha1-MVc3YcBX4zwukaq56W2gjO++duU=",
+          "integrity": "sha1-MVc3YcBX4zwukaq56W2gjO++duU="
+        },
+        "is-redirect": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
           "dev": true
         },
         "is-regex": {
@@ -12229,6 +13066,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
           "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+        },
+        "is-wsl": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+          "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+          "dev": true,
+          "requires": {
+            "is-docker": "^2.0.0"
+          }
         },
         "isarray": {
           "version": "0.0.1",
@@ -12359,10 +13205,30 @@
             "istanbul-lib-report": "^3.0.0"
           }
         },
+        "jake": {
+          "version": "10.8.2",
+          "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
+          "integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+          "dev": true,
+          "requires": {
+            "async": "0.9.x",
+            "chalk": "^2.4.2",
+            "filelist": "^1.0.1",
+            "minimatch": "^3.0.4"
+          },
+          "dependencies": {
+            "async": {
+              "version": "0.9.2",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+              "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+              "dev": true
+            }
+          }
+        },
         "js-cookie": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-          "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+          "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
           "dev": true
         },
         "js-tokens": {
@@ -12371,24 +13237,95 @@
           "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "^2.0.1"
           }
         },
         "jsbi": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.1.4.tgz",
-          "integrity": "sha512-52QRRFSsi9impURE8ZUbzAMCLjPm4THO7H2fcuIvaaeFTbSysvkodbQQXIVsNgq/ypDbq6dJiuGKL0vZ/i9hUg==",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.2.5.tgz",
+          "integrity": "sha512-aBE4n43IPvjaddScbvWRA2YlTzKEynHzu7MqOyTipdHucf/VxS63ViCjxYRg86M8Rxwbt/GfzHl1kKERkt45fQ==",
           "dev": true
         },
         "jsbn": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+        },
+        "jsdom": {
+          "version": "17.0.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-17.0.0.tgz",
+          "integrity": "sha512-MUq4XdqwtNurZDVeKScENMPHnkgmdIvMzZ1r1NSwHkDuaqI6BouPjr+17COo4/19oLNnmdpFDPOHVpgIZmZ+VA==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.5",
+            "acorn": "^8.4.1",
+            "acorn-globals": "^6.0.0",
+            "cssom": "^0.5.0",
+            "cssstyle": "^2.3.0",
+            "data-urls": "^3.0.0",
+            "decimal.js": "^10.3.1",
+            "domexception": "^2.0.1",
+            "escodegen": "^2.0.0",
+            "form-data": "^4.0.0",
+            "html-encoding-sniffer": "^2.0.1",
+            "http-proxy-agent": "^4.0.1",
+            "https-proxy-agent": "^5.0.0",
+            "is-potential-custom-element-name": "^1.0.1",
+            "nwsapi": "^2.2.0",
+            "parse5": "6.0.1",
+            "saxes": "^5.0.1",
+            "symbol-tree": "^3.2.4",
+            "tough-cookie": "^4.0.0",
+            "w3c-hr-time": "^1.0.2",
+            "w3c-xmlserializer": "^2.0.0",
+            "webidl-conversions": "^6.1.0",
+            "whatwg-encoding": "^1.0.5",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^9.0.0",
+            "ws": "^8.0.0",
+            "xml-name-validator": "^3.0.0"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "8.7.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+              "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+              "dev": true
+            },
+            "form-data": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+              "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+              "dev": true,
+              "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+              }
+            },
+            "tough-cookie": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+              "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+              "dev": true,
+              "requires": {
+                "psl": "^1.1.33",
+                "punycode": "^2.1.1",
+                "universalify": "^0.1.2"
+              }
+            },
+            "ws": {
+              "version": "8.4.1",
+              "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.1.tgz",
+              "integrity": "sha512-6eqQ4yN2y2xv8b+BgbkUzPPyfo/PDl3VOWb06ZE0jIFYwuHMsMQN6F7o84yxJYCblfCRAxzpU59We4Rr4w0Luw==",
+              "dev": true
+            }
+          }
         },
         "jsesc": {
           "version": "2.5.2",
@@ -12429,17 +13366,47 @@
           "integrity": "sha1-gF2vuzk5UYjO6atYLIHvlZ1+cQw=",
           "dev": true
         },
-        "jsonschema": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-          "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==",
-          "dev": true
-        },
-        "jsonschema-draft4": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/jsonschema-draft4/-/jsonschema-draft4-1.0.0.tgz",
-          "integrity": "sha1-8K8gBQVPDwrefqIRhhS2ncUS2GU=",
-          "dev": true
+        "jsonwebtoken": {
+          "version": "8.5.1",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+          "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+          "dev": true,
+          "requires": {
+            "jws": "^3.2.2",
+            "lodash.includes": "^4.3.0",
+            "lodash.isboolean": "^3.0.3",
+            "lodash.isinteger": "^4.0.4",
+            "lodash.isnumber": "^3.0.3",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.isstring": "^4.0.1",
+            "lodash.once": "^4.0.0",
+            "ms": "^2.1.1",
+            "semver": "^5.6.0"
+          },
+          "dependencies": {
+            "jws": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+              "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+              "dev": true,
+              "requires": {
+                "jwa": "^1.4.1",
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+              "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+              "dev": true
+            },
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
+          }
         },
         "jsprim": {
           "version": "1.4.1",
@@ -12469,19 +13436,43 @@
           }
         },
         "jws": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-          "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+          "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
           "dev": true,
           "requires": {
-            "jwa": "^1.4.1",
+            "jwa": "^2.0.0",
             "safe-buffer": "^5.0.1"
+          },
+          "dependencies": {
+            "jwa": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+              "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+              "dev": true,
+              "requires": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+              }
+            }
           }
         },
         "kebab-case": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.0.tgz",
           "integrity": "sha1-P55JkK3K0MaGwOcB92RYaPdfkes="
+        },
+        "keytar": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.7.0.tgz",
+          "integrity": "sha512-YEY9HWqThQc5q5xbXbRwsZTh2PJ36OSYRjSv3NN2xf5s5dpLTjEZnC2YikR29OaVybf9nQ0dJ/80i40RS97t/A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "node-addon-api": "^3.0.0",
+            "prebuild-install": "^6.0.0"
+          }
         },
         "languages4translatewiki": {
           "version": "0.1.3",
@@ -12550,21 +13541,19 @@
           }
         },
         "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "lodash.assignin": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
-          "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI=",
-          "dev": true
+          "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
         },
         "lodash.bind": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
-          "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=",
-          "dev": true
+          "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
@@ -12585,8 +13574,7 @@
         "lodash.filter": {
           "version": "4.6.0",
           "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-          "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=",
-          "dev": true
+          "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
         },
         "lodash.flatten": {
           "version": "4.4.0",
@@ -12601,18 +13589,30 @@
         "lodash.foreach": {
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-          "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
+          "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
+        },
+        "lodash.includes": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+          "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
           "dev": true
         },
-        "lodash.get": {
-          "version": "4.4.2",
-          "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-          "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+        "lodash.isboolean": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+          "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
+          "dev": true
         },
-        "lodash.isequal": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-          "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+        "lodash.isinteger": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+          "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
+          "dev": true
+        },
+        "lodash.isnumber": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+          "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
           "dev": true
         },
         "lodash.isplainobject": {
@@ -12620,41 +13620,47 @@
           "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
           "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
         },
+        "lodash.isstring": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+          "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+          "dev": true
+        },
         "lodash.map": {
           "version": "4.6.0",
           "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-          "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
-          "dev": true
+          "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
         },
         "lodash.merge": {
           "version": "4.6.2",
           "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-          "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+          "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+        },
+        "lodash.once": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+          "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
           "dev": true
         },
         "lodash.pick": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-          "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
-          "dev": true
+          "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
         },
         "lodash.reduce": {
           "version": "4.6.0",
           "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
-          "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs=",
-          "dev": true
+          "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
         },
         "lodash.reject": {
           "version": "4.6.0",
           "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
-          "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=",
-          "dev": true
+          "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
         },
         "lodash.some": {
           "version": "4.6.0",
           "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-          "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
-          "dev": true
+          "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
         },
         "lodash.union": {
           "version": "4.6.0",
@@ -12698,37 +13704,19 @@
           }
         },
         "log4js": {
-          "version": "0.6.35",
-          "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.35.tgz",
-          "integrity": "sha1-OrHafLFII7dO04ZcSFk6zfEfG1k=",
+          "version": "0.6.38",
+          "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
+          "integrity": "sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=",
           "dev": true,
           "requires": {
             "readable-stream": "~1.0.2",
             "semver": "~4.3.3"
           },
           "dependencies": {
-            "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
-              }
-            },
             "semver": {
               "version": "4.3.6",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
               "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-              "dev": true
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
               "dev": true
             }
           }
@@ -12770,9 +13758,9 @@
           }
         },
         "measured-core": {
-          "version": "1.11.2",
-          "resolved": "https://registry.npmjs.org/measured-core/-/measured-core-1.11.2.tgz",
-          "integrity": "sha1-nb6m0gdBtW9hq9hm5Jbri4Xmk0k=",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/measured-core/-/measured-core-2.0.0.tgz",
+          "integrity": "sha512-SIzGtX1WGDvR59FqcJaGEAqDueBvLBh6W4T/gQaHr5ufcqvQkUHGcfQhlmq77mkeF5Mo+UpD+8hm69CwUVibGw==",
           "dev": true,
           "requires": {
             "binary-search": "^1.3.3",
@@ -12809,17 +13797,24 @@
           "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
         },
         "mime-db": {
-          "version": "1.45.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-          "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
+          "version": "1.51.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+          "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
         },
         "mime-types": {
-          "version": "2.1.28",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
-          "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
+          "version": "2.1.34",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+          "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
           "requires": {
-            "mime-db": "1.45.0"
+            "mime-db": "1.51.0"
           }
+        },
+        "mimic-response": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+          "dev": true,
+          "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
@@ -12835,33 +13830,39 @@
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "minipass": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-          "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+          "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "yallist": "^4.0.0"
           }
         },
         "minizlib": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.9.0"
+            "minipass": "^3.0.0",
+            "yallist": "^4.0.0"
           }
         },
         "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true,
+          "optional": true
+        },
+        "mkdirp-classic": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+          "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+          "dev": true,
+          "optional": true
         },
         "mocha": {
           "version": "7.1.2",
@@ -12881,14 +13882,11 @@
             "js-yaml": "3.13.1",
             "log-symbols": "3.0.0",
             "minimatch": "3.0.4",
-            "mkdirp": "0.5.5",
             "ms": "2.1.1",
             "node-environment-flags": "1.0.6",
             "object.assign": "4.1.0",
             "strip-json-comments": "2.0.1",
             "supports-color": "6.0.0",
-            "which": "1.3.1",
-            "wide-align": "1.1.3",
             "yargs": "13.3.2",
             "yargs-parser": "13.1.2",
             "yargs-unparser": "1.6.0"
@@ -12925,7 +13923,6 @@
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
               "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
               "requires": {
-                "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
               }
             },
@@ -12946,29 +13943,28 @@
         },
         "mocha-froth": {
           "version": "0.2.10",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mocha-froth/-/mocha-froth-0.2.10.tgz",
           "integrity": "sha512-xyJqAYtm2zjrkG870hjeSVvGgS4Dc9tRokmN6R7XLgBKhdtAJ1ytU6zL045djblfHaPyTkSerQU4wqcjsv7Aew=="
         },
         "mock-json-schema": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/mock-json-schema/-/mock-json-schema-1.0.8.tgz",
-          "integrity": "sha512-22yL+WggSo8HXqw0HkXgXXJjJMSBCfv54htfwN4BabaFdJ3808jL0CzE+VaBRlj8Nr0+pnSVE9YvsDG5Quu6hQ==",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/mock-json-schema/-/mock-json-schema-1.1.1.tgz",
+          "integrity": "sha512-YV23vlsLP1EEOy0EviUvZTluXjLR+rhMzeayP2rcDiezj3RW01MhOSQkbQskdtg0K2fnGas5LKbSXgNjAOSX4A==",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.11",
-            "openapi-types": "^1.3.2"
+            "lodash": "^4.17.21"
           }
         },
         "mongodb": {
-          "version": "3.6.3",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
-          "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
+          "version": "3.7.3",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
+          "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
           "dev": true,
           "requires": {
             "bl": "^2.2.1",
             "bson": "^1.1.4",
             "denque": "^1.4.1",
-            "require_optional": "^1.0.1",
+            "optional-require": "^1.1.8",
             "safe-buffer": "^5.1.2",
             "saslprep": "^1.0.0"
           }
@@ -12978,21 +13974,40 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
-        "mssql": {
-          "version": "7.0.0-beta.2",
-          "resolved": "https://registry.npmjs.org/mssql/-/mssql-7.0.0-beta.2.tgz",
-          "integrity": "sha512-7fOp+QzFf24ir/gGeSvyyGlQKfxZj6tx88vsk4UiQw/t/zpJ9PLjOBOoi6Ff+Tw/CZ1aJTa83MPm+CRYJ/UCQA==",
+        "msal": {
+          "version": "1.4.15",
+          "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.15.tgz",
+          "integrity": "sha512-H/CxkeZJ4laEK6GZ/cDKQoYjBTvDNFK3hDC8mfU8IkuZvKFfFdo9KM89r8spXY7xnBK9SQBAjIuQgwUogeUw7g==",
           "dev": true,
           "requires": {
-            "debug": "^4",
+            "tslib": "^1.9.3"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+              "dev": true
+            }
+          }
+        },
+        "mssql": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/mssql/-/mssql-7.3.0.tgz",
+          "integrity": "sha512-3NGxDomH5Lci2g0EUrsejHIsvtFwlIE6A9SNFWQ2/JD4Dh0+5XVFHeyB4RXKb+nRMDosSUBAQDIVSuLXo5XFZA==",
+          "dev": true,
+          "requires": {
+            "@tediousjs/connection-string": "^0.3.0",
+            "debug": "^4.3.2",
+            "rfdc": "^1.3.0",
             "tarn": "^3.0.1",
-            "tedious": "^9.2.3"
+            "tedious": "^11.4.0"
           },
           "dependencies": {
             "debug": {
-              "version": "4.3.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-              "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+              "version": "4.3.3",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+              "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
               "dev": true,
               "requires": {
                 "ms": "2.1.2"
@@ -13057,34 +14072,46 @@
           }
         },
         "nano": {
-          "version": "8.2.3",
-          "resolved": "https://registry.npmjs.org/nano/-/nano-8.2.3.tgz",
-          "integrity": "sha512-nubyTQeZ/p+xf3ZFFMd7WrZwpcy9tUDrbaXw9HFBsM6zBY5gXspvOjvG2Zz3emT6nfJtP/h7F2/ESfsVVXnuMw==",
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/nano/-/nano-9.0.5.tgz",
+          "integrity": "sha512-fEAhwAdXh4hDDnC8cYJtW6D8ivOmpvFAqT90+zEuQREpRkzA/mJPcI4EKv15JUdajaqiLTXNoKK6PaRF+/06DQ==",
           "dev": true,
           "requires": {
-            "@types/request": "^2.48.4",
-            "cloudant-follow": "^0.18.2",
-            "debug": "^4.1.1",
-            "errs": "^0.3.2",
-            "request": "^2.88.0"
+            "@types/tough-cookie": "^4.0.0",
+            "axios": "^0.21.1",
+            "axios-cookiejar-support": "^1.0.1",
+            "qs": "^6.9.4",
+            "tough-cookie": "^4.0.0"
           },
           "dependencies": {
-            "debug": {
-              "version": "4.3.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-              "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+            "qs": {
+              "version": "6.10.3",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+              "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
               "dev": true,
               "requires": {
-                "ms": "2.1.2"
+                "side-channel": "^1.0.4"
               }
             },
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-              "dev": true
+            "tough-cookie": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+              "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+              "dev": true,
+              "requires": {
+                "psl": "^1.1.33",
+                "punycode": "^2.1.1",
+                "universalify": "^0.1.2"
+              }
             }
           }
+        },
+        "napi-build-utils": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+          "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+          "dev": true,
+          "optional": true
         },
         "native-duplexpair": {
           "version": "1.0.0",
@@ -13096,37 +14123,6 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
           "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
-        },
-        "needle": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.6.0.tgz",
-          "integrity": "sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "^3.2.6",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.2.7",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-              "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "ms": {
-              "version": "2.1.3",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-              "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-              "dev": true,
-              "optional": true
-            }
-          }
         },
         "negotiator": {
           "version": "0.6.2",
@@ -13156,10 +14152,35 @@
             }
           }
         },
+        "node-abi": {
+          "version": "2.30.1",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
+          "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "semver": "^5.4.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "node-abort-controller": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-2.0.0.tgz",
+          "integrity": "sha512-L8RfEgjBTHAISTuagw51PprVAqNZoG6KSB6LQ6H1bskMVkFs5E71IyjauLBv3XbuomJlguWF/VnRHdJ1gqiAqA==",
+          "dev": true
+        },
         "node-addon-api": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
-          "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+          "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
           "dev": true,
           "optional": true
         },
@@ -13180,87 +14201,55 @@
           }
         },
         "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-          "dev": true
-        },
-        "node-gyp": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
-          "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+          "version": "2.6.6",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+          "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "fstream": "^1.0.0",
-            "glob": "^7.0.3",
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "^0.5.0",
-            "nopt": "2 || 3",
-            "npmlog": "0 || 1 || 2 || 3 || 4",
-            "osenv": "0",
-            "request": "^2.87.0",
-            "rimraf": "2",
-            "semver": "~5.3.0",
-            "tar": "^2.0.0",
-            "which": "1"
+            "whatwg-url": "^5.0.0"
           },
           "dependencies": {
-            "semver": {
-              "version": "5.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+            "tr46": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+              "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+              "dev": true
+            },
+            "webidl-conversions": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+              "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+              "dev": true
+            },
+            "whatwg-url": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+              "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
               "dev": true,
-              "optional": true
+              "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+              }
             }
           }
         },
-        "node-pre-gyp": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
-          "integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
+        "node-gyp": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
+          "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          },
-          "dependencies": {
-            "nopt": {
-              "version": "4.0.3",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-              "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
-              }
-            },
-            "tar": {
-              "version": "4.4.13",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-              "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "chownr": "^1.1.1",
-                "fs-minipass": "^1.2.5",
-                "minipass": "^2.8.6",
-                "minizlib": "^1.2.1",
-                "mkdirp": "^0.5.0",
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.3"
-              }
-            }
+            "env-paths": "^2.2.0",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.2.3",
+            "nopt": "^5.0.0",
+            "npmlog": "^4.1.2",
+            "request": "^2.88.2",
+            "rimraf": "^3.0.2",
+            "semver": "^7.3.2",
+            "tar": "^6.0.2",
+            "which": "^2.0.2"
           }
         },
         "node-preload": {
@@ -13275,16 +14264,15 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/nodeify/-/nodeify-1.0.1.tgz",
           "integrity": "sha1-ZKtpp7268DzhB7TwM1yHwLnpGx0=",
-          "dev": true,
           "requires": {
             "is-promise": "~1.0.0",
             "promise": "~1.3.0"
           }
         },
         "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+          "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -13297,9 +14285,9 @@
           "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
         },
         "npm": {
-          "version": "6.14.8",
-          "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.8.tgz",
-          "integrity": "sha512-HBZVBMYs5blsj94GTeQZel7s9odVuuSUHy1+AlZh7rPVux1os2ashvEGLy/STNK7vUjbrCg5Kq9/GXisJgdf6A==",
+          "version": "6.14.15",
+          "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.15.tgz",
+          "integrity": "sha512-dkcQc4n+DiJAMYG2haNAMyJbmuvevjXz+WC9dCUzodw8EovwTIc6CATSsTEplCY6c0jG4OshxFGFJsrnKJguWA==",
           "dev": true,
           "requires": {
             "JSONStream": "^1.3.5",
@@ -13333,13 +14321,13 @@
             "glob": "^7.1.6",
             "graceful-fs": "^4.2.4",
             "has-unicode": "~2.0.1",
-            "hosted-git-info": "^2.8.8",
+            "hosted-git-info": "^2.8.9",
             "iferr": "^1.0.2",
             "imurmurhash": "*",
             "infer-owner": "^1.0.4",
             "inflight": "~1.0.6",
             "inherits": "^2.0.4",
-            "ini": "^1.3.5",
+            "ini": "^1.3.8",
             "init-package-json": "^1.10.3",
             "is-cidr": "^3.0.0",
             "json-parse-better-errors": "^1.0.2",
@@ -13382,10 +14370,10 @@
             "npm-pick-manifest": "^3.0.2",
             "npm-profile": "^4.0.4",
             "npm-registry-fetch": "^4.0.7",
-            "npm-user-validate": "~1.0.0",
+            "npm-user-validate": "^1.0.1",
             "npmlog": "~4.1.2",
             "once": "~1.4.0",
-            "opener": "^1.5.1",
+            "opener": "^1.5.2",
             "osenv": "^0.1.5",
             "pacote": "^9.5.12",
             "path-is-inside": "~1.0.2",
@@ -13409,9 +14397,9 @@
             "slide": "~1.1.6",
             "sorted-object": "~2.0.1",
             "sorted-union-stream": "~2.1.3",
-            "ssri": "^6.0.1",
+            "ssri": "^6.0.2",
             "stringify-package": "^1.0.1",
-            "tar": "^4.4.13",
+            "tar": "^4.4.19",
             "text-table": "~0.2.0",
             "tiny-relative-date": "^1.3.0",
             "uid-number": "0.0.6",
@@ -13459,18 +14447,6 @@
               "dev": true,
               "requires": {
                 "humanize-ms": "^1.2.1"
-              }
-            },
-            "ajv": {
-              "version": "5.5.2",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-              "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-              "dev": true,
-              "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
               }
             },
             "ansi-align": {
@@ -13847,12 +14823,6 @@
                 "graceful-fs": "^4.1.2",
                 "mkdirp": "~0.5.0"
               }
-            },
-            "co": {
-              "version": "4.6.0",
-              "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-              "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-              "dev": true
             },
             "code-point-at": {
               "version": "1.1.0",
@@ -14344,7 +15314,7 @@
               "dependencies": {
                 "get-stream": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
                   "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                   "dev": true
                 }
@@ -14360,12 +15330,6 @@
               "version": "1.3.0",
               "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
               "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-              "dev": true
-            },
-            "fast-deep-equal": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-              "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
               "dev": true
             },
             "fast-json-stable-stringify": {
@@ -14705,7 +15669,7 @@
               "dependencies": {
                 "get-stream": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
                   "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                   "dev": true
                 }
@@ -14724,13 +15688,39 @@
               "dev": true
             },
             "har-validator": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-              "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+              "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
               "dev": true,
               "requires": {
-                "ajv": "^5.3.0",
+                "ajv": "^6.12.3",
                 "har-schema": "^2.0.0"
+              },
+              "dependencies": {
+                "ajv": {
+                  "version": "6.12.6",
+                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                  "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                  "dev": true,
+                  "requires": {
+                    "fast-deep-equal": "^3.1.1",
+                    "fast-json-stable-stringify": "^2.0.0",
+                    "json-schema-traverse": "^0.4.1",
+                    "uri-js": "^4.2.2"
+                  }
+                },
+                "fast-deep-equal": {
+                  "version": "3.1.3",
+                  "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+                  "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+                  "dev": true
+                },
+                "json-schema-traverse": {
+                  "version": "0.4.1",
+                  "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                  "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+                  "dev": true
+                }
               }
             },
             "has": {
@@ -14761,9 +15751,9 @@
               "dev": true
             },
             "hosted-git-info": {
-              "version": "2.8.8",
-              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-              "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+              "version": "2.8.9",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+              "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
               "dev": true
             },
             "http-cache-semantics": {
@@ -14871,9 +15861,9 @@
               "dev": true
             },
             "ini": {
-              "version": "1.3.5",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-              "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+              "version": "1.3.8",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+              "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
               "dev": true
             },
             "init-package-json": {
@@ -15059,12 +16049,6 @@
               "version": "0.2.3",
               "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
               "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-              "dev": true
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-              "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
               "dev": true
             },
             "json-stringify-safe": {
@@ -15634,7 +16618,10 @@
                   "version": "1.10.0",
                   "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
                   "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "path-parse": "^1.0.6"
+                  }
                 }
               }
             },
@@ -15778,9 +16765,9 @@
               }
             },
             "npm-user-validate": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.0.tgz",
-              "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.1.tgz",
+              "integrity": "sha512-uQwcd/tY+h1jnEaze6cdX/LrhWhoBxfSknxentoqmIuStxUExxjWd3ULMLFPiFUrZKbOVMowH6Jq2FRWfmhcEw==",
               "dev": true
             },
             "npmlog": {
@@ -15839,9 +16826,9 @@
               }
             },
             "opener": {
-              "version": "1.5.1",
-              "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
-              "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+              "version": "1.5.2",
+              "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+              "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
               "dev": true
             },
             "os-homedir": {
@@ -15993,6 +16980,12 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
               "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+              "dev": true
+            },
+            "path-parse": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+              "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
               "dev": true
             },
             "performance-now": {
@@ -16556,9 +17549,9 @@
               }
             },
             "ssri": {
-              "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-              "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+              "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
               "dev": true,
               "requires": {
                 "figgy-pudding": "^3.5.1"
@@ -16709,18 +17702,18 @@
               }
             },
             "tar": {
-              "version": "4.4.13",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-              "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+              "version": "4.4.19",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+              "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
               "dev": true,
               "requires": {
-                "chownr": "^1.1.1",
-                "fs-minipass": "^1.2.5",
-                "minipass": "^2.8.6",
-                "minizlib": "^1.2.1",
-                "mkdirp": "^0.5.0",
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.3"
+                "chownr": "^1.1.4",
+                "fs-minipass": "^1.2.7",
+                "minipass": "^2.9.0",
+                "minizlib": "^1.3.3",
+                "mkdirp": "^0.5.5",
+                "safe-buffer": "^5.2.1",
+                "yallist": "^3.1.1"
               },
               "dependencies": {
                 "minipass": {
@@ -16732,6 +17725,18 @@
                     "safe-buffer": "^5.1.2",
                     "yallist": "^3.0.0"
                   }
+                },
+                "safe-buffer": {
+                  "version": "5.2.1",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                  "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+                  "dev": true
+                },
+                "yallist": {
+                  "version": "3.1.1",
+                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+                  "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+                  "dev": true
                 }
               }
             },
@@ -16903,6 +17908,23 @@
                 "latest-version": "^3.0.0",
                 "semver-diff": "^2.0.0",
                 "xdg-basedir": "^3.0.0"
+              }
+            },
+            "uri-js": {
+              "version": "4.4.0",
+              "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+              "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+              "dev": true,
+              "requires": {
+                "punycode": "^2.1.0"
+              },
+              "dependencies": {
+                "punycode": {
+                  "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+                  "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+                  "dev": true
+                }
               }
             },
             "url-parse-lax": {
@@ -17110,9 +18132,9 @@
               "dev": true
             },
             "y18n": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+              "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
               "dev": true
             },
             "yallist": {
@@ -17237,35 +18259,6 @@
             }
           }
         },
-        "npm-bundled": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-          "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "npm-normalize-package-bin": "^1.0.1"
-          }
-        },
-        "npm-normalize-package-bin": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
-          "dev": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
-          "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1",
-            "npm-normalize-package-bin": "^1.0.1"
-          }
-        },
         "npmlog": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -17283,7 +18276,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
           "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-          "dev": true,
           "requires": {
             "boolbase": "~1.0.0"
           }
@@ -17291,7 +18283,15 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true,
+          "optional": true
+        },
+        "nwsapi": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+          "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+          "dev": true
         },
         "nyc": {
           "version": "15.0.1",
@@ -17511,9 +18511,9 @@
           }
         },
         "observable-fns": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.5.1.tgz",
-          "integrity": "sha512-wf7g4Jpo1Wt2KIqZKLGeiuLOEMqpaOZ5gJn7DmSdqXgTdxRwSdBhWegQQpPteQ2gZvzCKqNNpwb853wcpA0j7A==",
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.6.1.tgz",
+          "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg==",
           "dev": true
         },
         "on-finished": {
@@ -17539,38 +18539,98 @@
             "wrappy": "1"
           }
         },
-        "openapi-backend": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/openapi-backend/-/openapi-backend-2.4.1.tgz",
-          "integrity": "sha512-48j8QhDD9sfV6t7Zgn9JrfJtCpJ53bmoT2bzXYYig1HhG/Xn0Aa5fJhM0cQSZq9nq78/XbU7RDEa3e+IADNkmA==",
+        "open": {
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+          "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
           "dev": true,
           "requires": {
-            "ajv": "^6.10.0",
+            "is-docker": "^2.0.0",
+            "is-wsl": "^2.1.1"
+          }
+        },
+        "openapi-backend": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/openapi-backend/-/openapi-backend-4.2.0.tgz",
+          "integrity": "sha512-eqdgJAjDbVZ7zhiIF68mlItFxqE48OPAM9nHHYx6BJMoGK2xInSBc2Oqp4dzsrsLIzoY8nVzK/vUtYktyXGb9Q==",
+          "dev": true,
+          "requires": {
+            "@apidevtools/json-schema-ref-parser": "^9.0.7",
+            "ajv": "^8.5.0",
             "bath-es5": "^3.0.3",
             "cookie": "^0.4.0",
             "lodash": "^4.17.15",
-            "mock-json-schema": "^1.0.5",
-            "openapi-schema-validation": "^0.4.2",
-            "openapi-types": "^1.3.4",
-            "qs": "^6.6.0",
-            "swagger-parser": "^9.0.1"
+            "mock-json-schema": "^1.0.7",
+            "openapi-schema-validator": "^9.2.0",
+            "openapi-types": "^9.2.0",
+            "qs": "^6.9.3"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "8.8.2",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+              "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+              "dev": true,
+              "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.2.2"
+              }
+            },
+            "json-schema-traverse": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+              "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+              "dev": true
+            },
+            "qs": {
+              "version": "6.10.3",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+              "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+              "dev": true,
+              "requires": {
+                "side-channel": "^1.0.4"
+              }
+            }
           }
         },
-        "openapi-schema-validation": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/openapi-schema-validation/-/openapi-schema-validation-0.4.2.tgz",
-          "integrity": "sha512-K8LqLpkUf2S04p2Nphq9L+3bGFh/kJypxIG2NVGKX0ffzT4NQI9HirhiY6Iurfej9lCu7y4Ndm4tv+lm86Ck7w==",
+        "openapi-schema-validator": {
+          "version": "9.3.1",
+          "resolved": "https://registry.npmjs.org/openapi-schema-validator/-/openapi-schema-validator-9.3.1.tgz",
+          "integrity": "sha512-5wpFKMoEbUcjiqo16jIen3Cb2+oApSnYZpWn8WQdRO2q/dNQZZl8Pz6ESwCriiyU5AK4i5ZI6+7O3bHQr6+6+g==",
           "dev": true,
           "requires": {
-            "jsonschema": "1.2.4",
-            "jsonschema-draft4": "^1.0.0",
-            "swagger-schema-official": "2.0.0-bab6bed"
+            "ajv": "^8.1.0",
+            "ajv-formats": "^2.0.2",
+            "lodash.merge": "^4.6.1",
+            "openapi-types": "^9.3.1"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "8.8.2",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+              "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+              "dev": true,
+              "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.2.2"
+              }
+            },
+            "json-schema-traverse": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+              "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+              "dev": true
+            }
           }
         },
         "openapi-types": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.5.tgz",
-          "integrity": "sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg==",
+          "version": "9.3.1",
+          "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.1.tgz",
+          "integrity": "sha512-/Yvsd2D7miYB4HLJ3hOOS0+vnowQpaT75FsHzr/y5M9P4q9bwa7RcbW2YdH6KZBn8ceLbKGnHxMZ1CHliGHUFw==",
           "dev": true
         },
         "optional-js": {
@@ -17578,6 +18638,15 @@
           "resolved": "https://registry.npmjs.org/optional-js/-/optional-js-2.3.0.tgz",
           "integrity": "sha512-B0LLi+Vg+eko++0z/b8zIv57kp7HKEzaPJo7LowJXMUKYdf+3XJGu/cw03h/JhIOsLnP+cG5QnTHAuicjA5fMw==",
           "dev": true
+        },
+        "optional-require": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
+          "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
+          "dev": true,
+          "requires": {
+            "require-at": "^1.0.6"
+          }
         },
         "optionator": {
           "version": "0.9.1",
@@ -17590,31 +18659,6 @@
             "prelude-ls": "^1.2.1",
             "type-check": "^0.4.0",
             "word-wrap": "^1.2.3"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
           }
         },
         "p-limit": {
@@ -17672,9 +18716,9 @@
           }
         },
         "parse5": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
-          "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+          "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
           "dev": true
         },
         "parseqs": {
@@ -17708,6 +18752,11 @@
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
         },
+        "path-parse": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+          "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+        },
         "path-to-regexp": {
           "version": "0.1.7",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -17720,24 +18769,24 @@
           "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "pg": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/pg/-/pg-8.5.1.tgz",
-          "integrity": "sha512-9wm3yX9lCfjvA98ybCyw2pADUivyNWT/yIP4ZcDVpMN0og70BUWYEGXPCTAQdGTAqnytfRADb7NERrY1qxhIqw==",
+          "version": "8.7.1",
+          "resolved": "https://registry.npmjs.org/pg/-/pg-8.7.1.tgz",
+          "integrity": "sha512-7bdYcv7V6U3KAtWjpQJJBww0UEsWuh4yQ/EjNf2HeO/NnvKjpvhEIe/A/TleP6wtmSKnUnghs5A9jUoK6iDdkA==",
           "dev": true,
           "requires": {
             "buffer-writer": "2.0.0",
             "packet-reader": "1.0.0",
-            "pg-connection-string": "^2.4.0",
-            "pg-pool": "^3.2.2",
-            "pg-protocol": "^1.4.0",
+            "pg-connection-string": "^2.5.0",
+            "pg-pool": "^3.4.1",
+            "pg-protocol": "^1.5.0",
             "pg-types": "^2.1.0",
             "pgpass": "1.x"
           }
         },
         "pg-connection-string": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
-          "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ==",
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+          "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==",
           "dev": true
         },
         "pg-int8": {
@@ -17747,15 +18796,15 @@
           "dev": true
         },
         "pg-pool": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.2.tgz",
-          "integrity": "sha512-ORJoFxAlmmros8igi608iVEbQNNZlp89diFVx6yV5v+ehmpMY9sK6QgpmgoXbmkNaBAx8cOOZh9g80kJv1ooyA==",
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.4.1.tgz",
+          "integrity": "sha512-TVHxR/gf3MeJRvchgNHxsYsTCHQ+4wm3VIHSS19z8NC0+gioEhq1okDY1sm/TYbfoP6JLFx01s0ShvZ3puP/iQ==",
           "dev": true
         },
         "pg-protocol": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.4.0.tgz",
-          "integrity": "sha512-El+aXWcwG/8wuFICMQjM5ZSAm6OWiJicFdNYo+VY3QP+8vI4SvLIWVe51PppTzMhikUJR+PsyIFKqfdXPz/yxA==",
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
+          "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==",
           "dev": true
         },
         "pg-types": {
@@ -17772,18 +18821,24 @@
           }
         },
         "pgpass": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.4.tgz",
-          "integrity": "sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==",
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+          "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
           "dev": true,
           "requires": {
-            "split2": "^3.1.1"
+            "split2": "^4.1.0"
           }
         },
         "picomatch": {
           "version": "2.2.2",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
           "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+        },
+        "pify": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+          "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
+          "dev": true
         },
         "pkg-dir": {
           "version": "4.2.0",
@@ -17852,10 +18907,38 @@
             "xtend": "^4.0.0"
           }
         },
+        "prebuild-install": {
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
+          "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "expand-template": "^2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.3",
+            "mkdirp-classic": "^0.5.3",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^2.21.0",
+            "npmlog": "^4.0.1",
+            "pump": "^3.0.0",
+            "rc": "^1.2.7",
+            "simple-get": "^3.0.3",
+            "tar-fs": "^2.0.0",
+            "tunnel-agent": "^0.6.0"
+          }
+        },
         "prelude-ls": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
           "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+        },
+        "process": {
+          "version": "0.11.10",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+          "dev": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
@@ -17879,7 +18962,6 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
           "integrity": "sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=",
-          "dev": true,
           "requires": {
             "is-promise": "~1"
           }
@@ -17894,12 +18976,12 @@
           }
         },
         "proxy-addr": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
-          "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+          "version": "2.0.7",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+          "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
           "dev": true,
           "requires": {
-            "forwarded": "~0.1.2",
+            "forwarded": "0.2.0",
             "ipaddr.js": "1.9.1"
           }
         },
@@ -17907,6 +18989,17 @@
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
           "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
         },
         "punycode": {
           "version": "2.1.1",
@@ -17941,9 +19034,9 @@
           "dev": true
         },
         "rate-limiter-flexible": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.2.1.tgz",
-          "integrity": "sha512-rxCP6kDDdn0cZmVqVlF06yLU+mG3TuwaHV/fUIw3OQyYhza7pzVBtdMhUmfXbBzMS+O464XP+x33pfTDGRGYVA==",
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.3.6.tgz",
+          "integrity": "sha512-8DVFOe89rreyut/vzwBI7vgXJynyYoYnH5XogtAKs0F/neAbCTTglXxSJ7fZeZamcFXZDvMidCBvps4KM+1srw==",
           "dev": true
         },
         "raw-body": {
@@ -17993,13 +19086,15 @@
           }
         },
         "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
           "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
           }
         },
         "readdirp": {
@@ -18011,21 +19106,21 @@
           }
         },
         "redis": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/redis/-/redis-3.0.2.tgz",
-          "integrity": "sha512-PNhLCrjU6vKVuMOyFu7oSP296mwBkcE6lrAjruBYG5LgdSqtRBoVQIylrMyVZD/lkF24RSNNatzvYag6HRBHjQ==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
+          "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
           "dev": true,
           "requires": {
-            "denque": "^1.4.1",
-            "redis-commands": "^1.5.0",
+            "denque": "^1.5.0",
+            "redis-commands": "^1.7.0",
             "redis-errors": "^1.2.0",
             "redis-parser": "^3.0.0"
           }
         },
         "redis-commands": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.6.0.tgz",
-          "integrity": "sha512-2jnZ0IkjZxvguITjFTrGiLyzQZcTvaw8DAaCXxZq/dsHXz7KfMQ3OUJy7Tz9vnRtZRVz6VRCPDvruvU8Ts44wQ==",
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+          "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
           "dev": true
         },
         "redis-errors": {
@@ -18049,13 +19144,13 @@
           "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q=="
         },
         "rehype": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/rehype/-/rehype-10.0.0.tgz",
-          "integrity": "sha512-0W8M4Y91b2QuzDSTjkZgBOJo79bP089YbSQNPMqebuUVrp6iveoi+Ra6/H7fJwUxq8FCHGCGzkLaq3fvO9XnVg==",
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/rehype/-/rehype-11.0.0.tgz",
+          "integrity": "sha512-qXqRqiCFJD5CJ61CSJuNImTFrm3zVkOU9XywHDwrUuvWN74MWt72KJ67c5CM5x8g0vGcOkRVCrYj85vqkmHulQ==",
           "dev": true,
           "requires": {
-            "rehype-parse": "^6.0.0",
-            "rehype-stringify": "^6.0.0",
+            "rehype-parse": "^7.0.0",
+            "rehype-stringify": "^8.0.0",
             "unified": "^9.0.0"
           }
         },
@@ -18080,24 +19175,22 @@
           }
         },
         "rehype-parse": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-6.0.2.tgz",
-          "integrity": "sha512-0S3CpvpTAgGmnz8kiCyFLGuW5yA4OQhyNTm/nwPopZ7+PI11WnGl1TTWTGv/2hPEe/g2jRLlhVVSsoDH8waRug==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-7.0.1.tgz",
+          "integrity": "sha512-fOiR9a9xH+Le19i4fGzIEowAbwG7idy2Jzs4mOrFWBSJ0sNUgy0ev871dwWnbOo371SjgjG4pwzrbgSVrKxecw==",
           "dev": true,
           "requires": {
-            "hast-util-from-parse5": "^5.0.0",
-            "parse5": "^5.0.0",
-            "xtend": "^4.0.0"
+            "hast-util-from-parse5": "^6.0.0",
+            "parse5": "^6.0.0"
           }
         },
         "rehype-stringify": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-6.0.1.tgz",
-          "integrity": "sha512-JfEPRDD4DiG7jet4md7sY07v6ACeb2x+9HWQtRPm2iA6/ic31hCv1SNBUtpolJASxQ/D8gicXiviW4TJKEMPKQ==",
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-8.0.0.tgz",
+          "integrity": "sha512-VkIs18G0pj2xklyllrPSvdShAV36Ff3yE5PUO9u36f6+2qJFnn22Z5gKwBOwgXviux4UC7K+/j13AnZfPICi/g==",
           "dev": true,
           "requires": {
-            "hast-util-to-html": "^6.0.0",
-            "xtend": "^4.0.0"
+            "hast-util-to-html": "^7.1.1"
           }
         },
         "release-zalgo": {
@@ -18144,6 +19237,12 @@
             }
           }
         },
+        "require-at": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+          "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==",
+          "dev": true
+        },
         "require-directory": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -18159,27 +19258,15 @@
           "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
         },
-        "require_optional": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-          "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
           "dev": true,
           "requires": {
-            "resolve-from": "^2.0.0",
-            "semver": "^5.1.0"
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
           }
-        },
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
-        },
-        "resolve-from": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-          "dev": true
         },
         "rethinkdb": {
           "version": "2.4.2",
@@ -18190,10 +19277,16 @@
             "bluebird": ">= 2.3.2 < 3"
           }
         },
+        "rfdc": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+          "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+          "dev": true
+        },
         "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -18226,6 +19319,15 @@
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true
         },
+        "saxes": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+          "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+          "dev": true,
+          "requires": {
+            "xmlchars": "^2.2.0"
+          }
+        },
         "security": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/security/-/security-1.0.0.tgz",
@@ -18233,9 +19335,13 @@
           "dev": true
         },
         "semver": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         },
         "send": {
           "version": "0.17.1",
@@ -18320,26 +19426,56 @@
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
         },
+        "side-channel": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+          "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "get-intrinsic": "^1.0.2",
+            "object-inspect": "^1.9.0"
+          }
+        },
         "signal-exit": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-          "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
+          "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ=="
+        },
+        "simple-concat": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+          "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+          "dev": true,
+          "optional": true
+        },
+        "simple-get": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+          "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "decompress-response": "^4.2.0",
+            "once": "^1.3.1",
+            "simple-concat": "^1.0.0"
+          }
         },
         "simple-git": {
-          "version": "2.31.0",
-          "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.31.0.tgz",
-          "integrity": "sha512-/+rmE7dYZMbRAfEmn8EUIOwlM2G7UdzpkC60KF86YAfXGnmGtsPrKsym0hKvLBdFLLW019C+aZld1+6iIVy5xA==",
+          "version": "2.48.0",
+          "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.48.0.tgz",
+          "integrity": "sha512-z4qtrRuaAFJS4PUd0g+xy7aN4y+RvEt/QTJpR184lhJguBA1S/LsVlvE/CM95RsYMOFJG3NGGDjqFCzKU19S/A==",
           "dev": true,
           "requires": {
             "@kwsites/file-exists": "^1.1.1",
             "@kwsites/promise-deferred": "^1.1.1",
-            "debug": "^4.3.1"
+            "debug": "^4.3.2"
           },
           "dependencies": {
             "debug": {
-              "version": "4.3.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-              "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+              "version": "4.3.3",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+              "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
               "dev": true,
               "requires": {
                 "ms": "2.1.2"
@@ -18427,8 +19563,7 @@
         "slide": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-          "dev": true
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
         },
         "socket.io": {
           "version": "2.4.1",
@@ -18556,9 +19691,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "source-map-support": {
-          "version": "0.5.19",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+          "version": "0.5.21",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+          "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -18613,29 +19748,26 @@
           }
         },
         "split2": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-          "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "^3.0.0"
-          }
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+          "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+          "dev": true
         },
         "sprintf-js": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+          "dev": true
         },
         "sqlite3": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.1.tgz",
-          "integrity": "sha512-kh2lTIcYNfmVcvhVJihsYuPj9U0xzBbh6bmqILO2hkryWSC9RRhzYmkIDtJkJ+d8Kg4wZRJ0T1reyHUEspICfg==",
+          "version": "github:mapbox/node-sqlite3#593c9d498be2510d286349134537e3bf89401c4a",
+          "from": "github:mapbox/node-sqlite3#593c9d498be2510d286349134537e3bf89401c4a",
           "dev": true,
           "optional": true,
           "requires": {
+            "@mapbox/node-pre-gyp": "^1.0.0",
             "node-addon-api": "^3.0.0",
-            "node-gyp": "3.x",
-            "node-pre-gyp": "^0.11.0"
+            "node-gyp": "7.x"
           }
         },
         "sqlstring": {
@@ -18666,10 +19798,18 @@
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
           "dev": true
         },
+        "stoppable": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+          "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+          "dev": true
+        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -18695,30 +19835,27 @@
           }
         },
         "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
         },
         "stringify-entities": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-2.0.0.tgz",
-          "integrity": "sha512-fqqhZzXyAM6pGD9lky/GOPq6V4X0SeTAFBl0iXb/BzOegl40gpf/bV3QQP7zULNYvjr6+Dx8SCaDULjVoOru0A==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-3.1.0.tgz",
+          "integrity": "sha512-3FP+jGMmMV/ffZs86MoghGqAoqXAdxLrJP4GUdrDN1aIScYih5tuIO3eF4To5AJZ79KDZ8Fpdy7QJnK8SsL1Vg==",
           "dev": true,
           "requires": {
             "character-entities-html4": "^1.0.0",
             "character-entities-legacy": "^1.0.0",
-            "is-alphanumerical": "^1.0.0",
-            "is-decimal": "^1.0.2",
-            "is-hexadecimal": "^1.0.0"
+            "xtend": "^4.0.0"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -18807,30 +19944,18 @@
           }
         },
         "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "swagger-parser": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-9.0.1.tgz",
-          "integrity": "sha512-oxOHUaeNetO9ChhTJm2fD+48DbGbLD09ZEOwPOWEqcW8J6zmjWxutXtSuOiXsoRgDWvORYlImbwM21Pn+EiuvQ==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "@apidevtools/swagger-parser": "9.0.1"
+            "has-flag": "^3.0.0"
           }
         },
-        "swagger-schema-official": {
-          "version": "2.0.0-bab6bed",
-          "resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
-          "integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0=",
-          "dev": true
-        },
-        "symbol-observable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+        "symbol-tree": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+          "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
           "dev": true
         },
         "table": {
@@ -18891,15 +20016,40 @@
           }
         },
         "tar": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-          "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+          "version": "6.1.11",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
           "dev": true,
           "optional": true,
           "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.12",
-            "inherits": "2"
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.1",
+            "mkdirp": "^1.0.3",
+            "yallist": "^4.0.0"
+          },
+          "dependencies": {
+            "chownr": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+              "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "tar-fs": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+          "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "mkdirp-classic": "^0.5.2",
+            "pump": "^3.0.0",
+            "tar-stream": "^2.1.4"
           }
         },
         "tar-stream": {
@@ -18923,41 +20073,73 @@
                 "inherits": "^2.0.4",
                 "readable-stream": "^3.4.0"
               }
+            },
+            "readable-stream": {
+              "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+              "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+              "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+              "requires": {
+                "safe-buffer": "~5.2.0"
+              }
             }
           }
         },
         "tarn": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.1.tgz",
-          "integrity": "sha512-6usSlV9KyHsspvwu2duKH+FMUhqJnAh6J5J/4MITl8s94iSUQTLkJggdiewKv4RyARQccnigV48Z+khiuVZDJw==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.2.tgz",
+          "integrity": "sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==",
           "dev": true
         },
         "tedious": {
-          "version": "9.2.3",
-          "resolved": "https://registry.npmjs.org/tedious/-/tedious-9.2.3.tgz",
-          "integrity": "sha512-+mI2r/5mqxpTHKBZ/SW+NNH2MK5i3Pwwkw0gF5ZrS2wf2uT/03bLSss8nm7xh604abJXyjx0sirhwH63H328qA==",
+          "version": "11.8.0",
+          "resolved": "https://registry.npmjs.org/tedious/-/tedious-11.8.0.tgz",
+          "integrity": "sha512-GtFrO694x/7CRiUBt0AI4jrMtrkXV+ywifiOrDy4K0ufJLeKB4rgmPjy5Ws366fCaBaKlqQ9RnJ+sCJ1Jbd1lw==",
           "dev": true,
           "requires": {
+            "@azure/identity": "^1.3.0",
+            "@azure/keyvault-keys": "^4.1.0",
             "@azure/ms-rest-nodeauth": "^3.0.6",
-            "@js-joda/core": "^3.1.0",
-            "adal-node": "^0.1.28",
-            "bl": "^3.0.0",
+            "@js-joda/core": "^3.2.0",
+            "adal-node": "^0.2.1",
+            "bl": "^5.0.0",
             "depd": "^2.0.0",
-            "iconv-lite": "^0.6.2",
-            "jsbi": "^3.1.3",
+            "iconv-lite": "^0.6.3",
+            "jsbi": "^3.1.5",
             "native-duplexpair": "^1.0.0",
+            "node-abort-controller": "^2.0.0",
             "punycode": "^2.1.0",
-            "readable-stream": "^3.6.0",
             "sprintf-js": "^1.1.2"
           },
           "dependencies": {
             "bl": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.1.tgz",
-              "integrity": "sha512-jrCW5ZhfQ/Vt07WX1Ngs+yn9BDqPL/gw28S7s9H6QK/gupnizNzJAss5akW20ISgOrbLTlXOOCTJeNUQqruAWQ==",
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
+              "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
               "dev": true,
               "requires": {
-                "readable-stream": "^3.0.1"
+                "buffer": "^6.0.3",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+              }
+            },
+            "buffer": {
+              "version": "6.0.3",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+              "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+              "dev": true,
+              "requires": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
               }
             },
             "depd": {
@@ -18967,31 +20149,53 @@
               "dev": true
             },
             "iconv-lite": {
-              "version": "0.6.2",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-              "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+              "version": "0.6.3",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+              "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
               "dev": true,
               "requires": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
               }
             },
-            "sprintf-js": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-              "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-              "dev": true
+            "readable-stream": {
+              "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+              "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+              "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.2.0"
+              }
             }
           }
         },
         "terser": {
-          "version": "4.8.0",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-          "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+          "version": "5.10.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
+          "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
           "dev": true,
           "requires": {
             "commander": "^2.20.0",
-            "source-map": "~0.6.1",
-            "source-map-support": "~0.5.12"
+            "source-map": "~0.7.2",
+            "source-map-support": "~0.5.20"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.7.3",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+              "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+              "dev": true
+            }
           }
         },
         "test-exclude": {
@@ -19010,22 +20214,22 @@
           "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
         },
         "threads": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.3.tgz",
-          "integrity": "sha512-tKwFIWRgfAT85KGkrpDt2jWPO8IVH0sLNfB/pXad/VW9eUIY2Zlz+QyeizypXhPHv9IHfqRzvk2t3mPw+imhWw==",
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/threads/-/threads-1.7.0.tgz",
+          "integrity": "sha512-Mx5NBSHX3sQYR6iI9VYbgHKBLisyB+xROCBGjjWm1O9wb9vfLxdaGtmT/KCjUqMsSNW6nERzCW3T6H43LqjDZQ==",
           "dev": true,
           "requires": {
             "callsites": "^3.1.0",
-            "debug": "^4.1.1",
-            "is-observable": "^1.1.0",
-            "observable-fns": "^0.5.1",
+            "debug": "^4.2.0",
+            "is-observable": "^2.1.0",
+            "observable-fns": "^0.6.1",
             "tiny-worker": ">= 2"
           },
           "dependencies": {
             "debug": {
-              "version": "4.3.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-              "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+              "version": "4.3.3",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+              "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
               "dev": true,
               "requires": {
                 "ms": "2.1.2"
@@ -19049,9 +20253,9 @@
           }
         },
         "tinycon": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/tinycon/-/tinycon-0.0.1.tgz",
-          "integrity": "sha1-beEM1SGaHxIdmgokssEbP7JN/+0=",
+          "version": "0.6.8",
+          "resolved": "https://registry.npmjs.org/tinycon/-/tinycon-0.6.8.tgz",
+          "integrity": "sha1-59oiPj7gy/nbeWP6M1aZuyF3enM=",
           "dev": true
         },
         "to-array": {
@@ -19088,6 +20292,15 @@
             "punycode": "^2.1.1"
           }
         },
+        "tr46": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+          "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
         "trough": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
@@ -19095,9 +20308,9 @@
           "dev": true
         },
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
           "dev": true
         },
         "tunnel": {
@@ -19156,25 +20369,24 @@
           }
         },
         "ueberdb2": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/ueberdb2/-/ueberdb2-1.2.5.tgz",
-          "integrity": "sha512-Bts6kmVvhVDWiZjD1JAT1qYknHHK6t9L7kGIFIedGAZRNQ3lRw2XJdf9hKbFpN2HM0J3S/aJoLrZO5BLk3UiaA==",
+          "version": "1.4.19",
+          "resolved": "https://registry.npmjs.org/ueberdb2/-/ueberdb2-1.4.19.tgz",
+          "integrity": "sha512-9D4C9Lpb4fIHf7mdGOd24oYmrE/snEiz907rgWjVOTH/cN4O1kOuRW7VEaUatj9zDUdbne6W9wwypat/CYtZDQ==",
           "dev": true,
           "requires": {
-            "async": "^3.2.0",
-            "cassandra-driver": "^4.5.1",
-            "channels": "0.0.4",
-            "dirty": "^1.1.0",
-            "elasticsearch": "^16.7.1",
-            "mongodb": "^3.6.3",
-            "mssql": "^7.0.0-beta.2",
+            "async": "^3.2.2",
+            "cassandra-driver": "^4.6.3",
+            "dirty": "^1.1.3",
+            "elasticsearch": "^16.7.2",
+            "mongodb": "^3.7.3",
+            "mssql": "^7.3.0",
             "mysql": "2.18.1",
-            "nano": "^8.2.2",
-            "pg": "^8.0.3",
-            "redis": "^3.0.2",
+            "nano": "^9.0.5",
+            "pg": "^8.7.1",
+            "redis": "^3.1.2",
             "rethinkdb": "^2.4.2",
-            "simple-git": "^2.4.0",
-            "sqlite3": "^5.0.1"
+            "simple-git": "^2.47.0",
+            "sqlite3": "github:mapbox/node-sqlite3#593c9d498be2510d286349134537e3bf89401c4a"
           }
         },
         "uid-safe": {
@@ -19187,15 +20399,15 @@
           }
         },
         "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+          "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
           "dev": true
         },
         "unified": {
-          "version": "9.2.0",
-          "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.0.tgz",
-          "integrity": "sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==",
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
+          "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
           "dev": true,
           "requires": {
             "bail": "^1.0.0",
@@ -19207,9 +20419,9 @@
           }
         },
         "unist-util-is": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+          "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
           "dev": true
         },
         "unist-util-stringify-position": {
@@ -19221,10 +20433,16 @@
             "@types/unist": "^2.0.2"
           }
         },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
+        },
         "unorm": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.4.1.tgz",
-          "integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA=",
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+          "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
           "dev": true
         },
         "unpipe": {
@@ -19262,12 +20480,6 @@
           "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
           "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q=="
         },
-        "validator": {
-          "version": "12.2.0",
-          "resolved": "https://registry.npmjs.org/validator/-/validator-12.2.0.tgz",
-          "integrity": "sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ==",
-          "dev": true
-        },
         "vargs": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz",
@@ -19301,6 +20513,12 @@
             "vfile-message": "^2.0.0"
           }
         },
+        "vfile-location": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.2.0.tgz",
+          "integrity": "sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA==",
+          "dev": true
+        },
         "vfile-message": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
@@ -19311,6 +20529,24 @@
             "unist-util-stringify-position": "^2.0.0"
           }
         },
+        "w3c-hr-time": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+          "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+          "dev": true,
+          "requires": {
+            "browser-process-hrtime": "^1.0.0"
+          }
+        },
+        "w3c-xmlserializer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+          "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+          "dev": true,
+          "requires": {
+            "xml-name-validator": "^3.0.0"
+          }
+        },
         "wd": {
           "version": "1.12.1",
           "resolved": false,
@@ -19319,7 +20555,6 @@
             "archiver": "^3.0.0",
             "async": "^2.0.0",
             "lodash": "^4.0.0",
-            "mkdirp": "^0.5.1",
             "q": "^1.5.1",
             "request": "2.88.0",
             "vargs": "^0.1.0"
@@ -19387,10 +20622,54 @@
           "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
           "dev": true
         },
+        "webidl-conversions": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+          "dev": true
+        },
+        "whatwg-encoding": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+          "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+          "dev": true,
+          "requires": {
+            "iconv-lite": "0.4.24"
+          }
+        },
+        "whatwg-mimetype": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+          "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-9.1.0.tgz",
+          "integrity": "sha512-CQ0UcrPHyomtlOCot1TL77WyMIm/bCwrJ2D6AOKGwEczU9EpyoqAokfqrf/MioU9kHcMsmJZcg1egXix2KYEsA==",
+          "dev": true,
+          "requires": {
+            "tr46": "^2.1.0",
+            "webidl-conversions": "^6.1.0"
+          },
+          "dependencies": {
+            "tr46": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+              "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+              "dev": true,
+              "requires": {
+                "punycode": "^2.1.1"
+              }
+            }
+          }
+        },
         "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -19401,11 +20680,13 @@
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
         },
         "wide-align": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+          "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+          "dev": true,
+          "optional": true,
           "requires": {
-            "string-width": "^1.0.2 || 2"
+            "string-width": "^1.0.2 || 2 || 3 || 4"
           }
         },
         "word-wrap": {
@@ -19487,6 +20768,18 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
           "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
         },
+        "wtfnode": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/wtfnode/-/wtfnode-0.9.1.tgz",
+          "integrity": "sha512-Ip6C2KeQPl/F3aP1EfOnPoQk14Udd9lffpoqWDNH3Xt78svxPbv53ngtmtfI0q2Te3oTq79XKTnRNXVIn/GsPA==",
+          "dev": true
+        },
+        "xml-name-validator": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+          "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+          "dev": true
+        },
         "xml2js": {
           "version": "0.4.23",
           "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
@@ -19503,10 +20796,10 @@
           "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
           "dev": true
         },
-        "xmldom": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.4.0.tgz",
-          "integrity": "sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA==",
+        "xmlchars": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+          "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
           "dev": true
         },
         "xmlhttprequest-ssl": {
@@ -19532,9 +20825,9 @@
           "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
         },
         "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true,
           "optional": true
         },
@@ -19614,26 +20907,13 @@
           "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
           "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
         },
-        "z-schema": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.3.tgz",
-          "integrity": "sha512-zkvK/9TC6p38IwcrbnT3ul9in1UX4cm1y/VZSs4GHKIiDCrlafc+YQBgQBUdDXLAoZHf2qvQ7gJJOo6yT1LH6A==",
-          "dev": true,
-          "requires": {
-            "commander": "^2.7.1",
-            "lodash.get": "^4.4.2",
-            "lodash.isequal": "^4.5.0",
-            "validator": "^12.0.0"
-          }
-        },
         "zip-stream": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",
           "integrity": "sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==",
           "requires": {
             "archiver-utils": "^2.1.0",
-            "compress-commons": "^2.1.1",
-            "readable-stream": "^3.4.0"
+            "compress-commons": "^2.1.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/jquery": "^3.5.5",
     "@types/lodash": "^4.14.169",
     "@types/node": "^10.17.51",
+    "@types/simple-oauth2": "^4.1.1",
     "@typescript-eslint/eslint-plugin": "^4.24.0",
     "@typescript-eslint/parser": "^4.24.0",
     "ep_etherpad-lite": "file:../etherpad-lite/src",
@@ -56,7 +57,6 @@
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
-    "ep_etherpad-lite": "^1.8.7",
-    "express": "^4.17.1"
+    "ep_etherpad-lite": "^1.8.7"
   }
 }

--- a/src/client/document-ready.ts
+++ b/src/client/document-ready.ts
@@ -32,21 +32,28 @@ const initializeMonetization = () => {
 
 const syncElements = [
   '#ep_permanent_exporter-log-in',
+  '#ep_permanent_exporter-log-in-pending',
   '#ep_permanent_exporter-sync-disabled',
   '#ep_permanent_exporter-sync-pending',
   '#ep_permanent_exporter-sync-enabled',
 ];
 
 const checkPermanentSyncStatus = async () => {
-  const { loggedInToPermanent, sync } = await $.getJSON(`${padUrl()}/permanent`);
+  const { loginStatus } = await $.getJSON('/permanent/status');
+  const { sync } = await $.getJSON(`${padUrl()}/permanent`);
 
-  if (sync === true) {
-    showOneOfGroup(syncElements, 'sync-enabled');
-  } else if (loggedInToPermanent && sync === 'pending') {
-    showOneOfGroup(syncElements, 'sync-pending');
+  if (loginStatus === 'logged-in') {
+    if (sync === true) {
+      showOneOfGroup(syncElements, 'sync-enabled');
+    } else if (sync === 'pending') {
+      showOneOfGroup(syncElements, 'sync-pending');
+      setTimeout(checkPermanentSyncStatus, 1000);
+    } else {
+      showOneOfGroup(syncElements, 'sync-disabled');
+    }
+  } else if (loginStatus === 'pending') {
+    showOneOfGroup(syncElements, 'log-in-pending');
     setTimeout(checkPermanentSyncStatus, 1000);
-  } else if (loggedInToPermanent) {
-    showOneOfGroup(syncElements, 'sync-disabled');
   } else {
     showOneOfGroup(syncElements, 'log-in');
   }

--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -145,8 +145,8 @@ const router = express.Router({ mergeParams: true });
 router.use([
   cookieParser(),
 ]);
-router.get('/', getPadPermanentConfig);
-router.post('/', enableSync);
-router.delete('/', disableSync);
+router.get('/p/:pad/permanent', getPadPermanentConfig);
+router.post('/p/:pad/permanent', enableSync);
+router.delete('/p/:pad/permanent', disableSync);
 
 export { router };

--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -11,7 +11,7 @@ import {
   setSyncConfig,
 } from '../database';
 import { getSyncTarget } from '../permanent-client';
-import { authorTokenIsLive, client, getOrRefreshToken } from '../permanent-oauth';
+import { authorTokenIsLive, client, getToken } from '../permanent-oauth';
 import { pluginSettings } from '../settings';
 import type {
   Handler,
@@ -24,7 +24,7 @@ const authorIsLoggedInToPermanent: Handler = async (
   res: Response,
 ): Promise<void> => {
   const author = await getAuthor4Token(req.cookies.token);
-  const { status } = await getOrRefreshToken(author);
+  const { status } = await getToken(author);
   switch(status) {
     case 'refreshing':
       res.json({ loginStatus: 'pending' });
@@ -33,7 +33,6 @@ const authorIsLoggedInToPermanent: Handler = async (
       res.json({ loginStatus: 'logged-out' });
       return;
     case 'live':
-    case 'valid':
       res.json({ loginStatus: 'logged-in' });
       return;
     default:
@@ -67,7 +66,7 @@ const enableSync: Handler = async (
   try {
     const author = await getAuthor4Token(req.cookies.token);
     const config = await getSyncConfig(req.params.pad, author);
-    const authorToken = await getOrRefreshToken(author);
+    const authorToken = await getToken(author);
 
     if (!authorTokenIsLive(authorToken)) {
       res.status(401).json({

--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -1,45 +1,56 @@
 /* eslint-disable no-console -- console logging is a useful initial prototype */
 
-import cookieParser from 'cookie-parser';
 import express from 'express';
 import { getAuthor4Token } from 'ep_etherpad-lite/node/db/AuthorManager';
 import {
   SyncConfig,
+  deleteAuthorToken,
   deleteSyncConfig,
   getSyncConfig,
+  setAuthorToken,
   setSyncConfig,
 } from '../database';
 import { getSyncTarget } from '../permanent-client';
+import { authorTokenIsLive, client, getOrRefreshToken } from '../permanent-oauth';
+import { pluginSettings } from '../settings';
 import type {
   Handler,
   Request,
   Response,
 } from 'express';
 
-const hasSessionCookies = (req: Request): boolean => (
-  'cookies' in req
-  && 'permMFA' in req.cookies
-  && 'permSession' in req.cookies
-);
-
-const isInvalidSession = (req: Request, config: SyncConfig): boolean => (
-  hasSessionCookies(req)
-  && config.sync === 'invalid'
-  && req.cookies.permMFA === config.credentials.mfa
-  && req.cookies.permSession === config.credentials.session
-);
+const authorIsLoggedInToPermanent: Handler = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  const author = await getAuthor4Token(req.cookies.token);
+  const { status } = await getOrRefreshToken(author);
+  switch(status) {
+    case 'refreshing':
+      res.json({ loginStatus: 'pending' });
+      return;
+    case 'missing':
+      res.json({ loginStatus: 'logged-out' });
+      return;
+    case 'valid':
+      res.json({ loginStatus: 'logged-in' });
+      return;
+    default:
+      // log an error? idk
+      res.json({ loginStatus: 'logged-out' });
+      return;
+  }
+};
 
 const getPadPermanentConfig: Handler = async (
   req: Request,
   res: Response,
 ): Promise<void> => {
-  console.log('get permanent config for pad id', req.params.pad);
   try {
     const author = await getAuthor4Token(req.cookies.token);
-    const config = await getSyncConfig(req.params.pad, author);
+    const { sync } = await getSyncConfig(req.params.pad, author);
     res.json({
-      loggedInToPermanent: hasSessionCookies(req) && !isInvalidSession(req, config),
-      sync: config.sync,
+      sync,
     });
   } catch (err: unknown) {
     res.json({
@@ -55,24 +66,18 @@ const enableSync: Handler = async (
   try {
     const author = await getAuthor4Token(req.cookies.token);
     const config = await getSyncConfig(req.params.pad, author);
+    const authorToken = await getOrRefreshToken(author);
 
-    if (!hasSessionCookies(req) || isInvalidSession(req, config)) {
+    if (!authorTokenIsLive(authorToken)) {
       res.status(401).json({
-        loggedInToPermanent: false,
         sync: config.sync,
       });
       return;
     }
 
-    const { permMFA, permSession } = req.cookies;
-
-    if (config.sync !== false
-      && config.credentials.mfa === permMFA
-      && config.credentials.session === permSession
-    ) {
+    if (config.sync !== false) {
       const status = config.sync === true ? 200 : 202;
       res.status(status).json({
-        loggedInToPermanent: true,
         sync: config.sync,
       });
       return;
@@ -81,38 +86,30 @@ const enableSync: Handler = async (
     setSyncConfig(req.params.pad, author, {
       sync: 'pending',
       credentials: {
-        type: 'cookies',
-        session: permSession,
-        mfa: permMFA,
+        type: 'author',
+        author,
       },
     });
 
     res.status(202).json({
-      loggedInToPermanent: true,
       sync: 'pending',
     });
 
     setImmediate(() => {
-      getSyncTarget(permSession, permMFA)
+      getSyncTarget(authorToken)
         .then((target) => setSyncConfig(req.params.pad, author, {
           sync: true,
           credentials: {
-            type: 'cookies',
-            session: permSession,
-            mfa: permMFA,
+            type: 'author',
+            author: author,
           },
           target,
         }))
         .catch((error: unknown) => {
           console.log('Error trying to find/create Etherpad folder', typeof error, error);
-          setSyncConfig(req.params.pad, author, {
-            sync: 'invalid',
-            credentials: {
-              type: 'cookies',
-              session: permSession,
-              mfa: permMFA,
-            },
-          });
+          console.log((error as object).toString());
+          deleteSyncConfig(req.params.pad, author);
+          // TODO: delete author token because it's invalid, maybe?
         });
     });
   } catch (err: unknown) {
@@ -131,7 +128,6 @@ const disableSync: Handler = async (
     const config = await getSyncConfig(req.params.pad, author);
     deleteSyncConfig(req.params.pad, author);
     res.status(202).json({
-      loggedInToPermanent: hasSessionCookies(req) && !isInvalidSession(req, config),
       sync: config.sync,
     });
   } catch (err: unknown) {
@@ -141,12 +137,53 @@ const disableSync: Handler = async (
   }
 };
 
+const redirectIdP: Handler = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  // todo: save current URL to database to redirect to after
+  res.redirect(client.authorizeUrl(
+    `${req.protocol}://${req.get('host')}/permanent/callback`,
+    'offline_access',
+    'state',
+  ));
+}
+
+const completeOauth: Handler = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  const { code, state } = req.query;
+  const author = await getAuthor4Token(req.cookies.token);
+
+  try {
+    const token = await client.completeAuthorization(
+      `${req.protocol}://${req.get('host')}/permanent/callback`,
+      code as string,
+      'offline_access',
+      state as string,
+    );
+
+    await setAuthorToken(author, {
+      status: 'valid',
+      token,
+    });
+
+    // todo: load old URL from database to redirect to
+    res.redirect(`${req.baseUrl}/`);
+  } catch(error: unknown) {
+    await deleteAuthorToken(author);
+    console.log('Error completing OAuth authorization grant', error);
+    res.status(401).json({ loginStatus: 'logged-out' });
+  }
+}
+
 const router = express.Router({ mergeParams: true });
-router.use([
-  cookieParser(),
-]);
 router.get('/p/:pad/permanent', getPadPermanentConfig);
 router.post('/p/:pad/permanent', enableSync);
 router.delete('/p/:pad/permanent', disableSync);
+router.get('/permanent/auth', redirectIdP);
+router.get('/permanent/callback', completeOauth);
+router.get('/permanent/status', authorIsLoggedInToPermanent);
 
 export { router };

--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -32,6 +32,7 @@ const authorIsLoggedInToPermanent: Handler = async (
     case 'missing':
       res.json({ loginStatus: 'logged-out' });
       return;
+    case 'live':
     case 'valid':
       res.json({ loginStatus: 'logged-in' });
       return;
@@ -166,7 +167,7 @@ const completeOauth: Handler = async (
 
     await setAuthorToken(author, {
       status: 'valid',
-      token,
+      token: token.token,
     });
 
     // todo: load old URL from database to redirect to

--- a/src/server/database.ts
+++ b/src/server/database.ts
@@ -7,7 +7,7 @@ import {
 
 import type { AccessToken } from 'simple-oauth2';
 
-interface AuthorTokenMissing {
+export interface AuthorTokenMissing {
   status: 'missing';
 }
 
@@ -47,7 +47,7 @@ const setAuthorToken = async (
 
 const deleteAuthorToken = async (
   authorId: string,
-): Promise<SyncConfig> => (
+): Promise<null> => (
   remove(`permanent:${authorId}`)
 );
 

--- a/src/server/database.ts
+++ b/src/server/database.ts
@@ -30,6 +30,27 @@ export interface AuthorTokenLive {
 export type AuthorToken = AuthorTokenMissing | AuthorTokenRefreshing
   | AuthorTokenValid | AuthorTokenLive;
 
+const getAuthorToken = async (
+  authorId: string,
+): Promise<AuthorTokenMissing | AuthorTokenRefreshing | AuthorTokenValid> => (
+  await get(`permanent:${authorId}`) || {
+    status: 'missing',
+  }
+);
+
+const setAuthorToken = async (
+  authorId: string,
+  authorToken: AuthorTokenRefreshing | AuthorTokenValid,
+): Promise<null> => (
+  set(`permanent:${authorId}`, authorToken)
+);
+
+const deleteAuthorToken = async (
+  authorId: string,
+): Promise<SyncConfig> => (
+  remove(`permanent:${authorId}`)
+);
+
 interface SyncConfigDisabled {
   sync: false;
 }
@@ -59,27 +80,6 @@ export interface SyncConfigEnabled {
 
 export type SyncConfig = SyncConfigDisabled | SyncConfigPending
  | SyncConfigEnabled;
-
-const getAuthorToken = async (
-  authorId: string,
-): Promise<AuthorTokenMissing | AuthorTokenRefreshing | AuthorTokenValid> => (
-  await get(`permanent:${authorId}`) || {
-    status: 'missing',
-  }
-);
-
-const setAuthorToken = async (
-  authorId: string,
-  authorToken: AuthorTokenMissing | AuthorTokenRefreshing | AuthorTokenValid,
-): Promise<null> => (
-  await set(`permanent:${authorId}`, authorToken)
-);
-
-const deleteAuthorToken = async (
-  authorId: string,
-): Promise<SyncConfig> => (
-  remove(`permanent:${authorId}`)
-);
 
 const getSyncConfig = async (
   padId: string,

--- a/src/server/export-column.ts
+++ b/src/server/export-column.ts
@@ -5,7 +5,7 @@ const eejsBlock_exportColumn = (hookName: string, args: { content: string }) => 
   args.content += eejs.require(
     'ep_permanent_exporter/templates/exportColumn.html',
     {
-      loginUrl: pluginSettings.loginUrl,
+      loginUrl: '/permanent/auth',
     },
   );
 };

--- a/src/server/express-create-server.ts
+++ b/src/server/express-create-server.ts
@@ -5,7 +5,7 @@ const expressCreateServer = (
   hookName: string,
   context: { app: Application },
 ) => {
-  context.app.use('/p/:pad/permanent', router);
+  context.app.use(router);
 };
 
 export { expressCreateServer };

--- a/src/server/pad-update.ts
+++ b/src/server/pad-update.ts
@@ -37,7 +37,8 @@ const debounceUpdate = debounce(async (pad: Pad): Promise<void> => {
               pad.atext.text,
             );
           } catch (err: any) {
-            console.log('Error uploading text', credentials.author, pad.id, typeof err, err);
+            console.log('Error uploading text', credentials.author, pad.id, typeof err,
+              err.stack || err.message || String(err));
           }
           return;
         default:

--- a/src/server/pad-update.ts
+++ b/src/server/pad-update.ts
@@ -26,9 +26,6 @@ const debounceUpdate = debounce(async (pad: Pad): Promise<void> => {
         case 'missing':
           deleteSyncConfig(pad.id, credentials.author);
           return;
-        case 'refreshing':
-          // todo
-          return;
         case 'live':
           try {
             await uploadText(
@@ -39,8 +36,8 @@ const debounceUpdate = debounce(async (pad: Pad): Promise<void> => {
               `Text of ${pad.id} at revision ${pad.head}`,
               pad.atext.text,
             );
-          } catch (err: unknown) {
-            console.log('Error uploading text', credentials.author, pad.id, err);
+          } catch (err: any) {
+            console.log('Error uploading text', credentials.author, pad.id, typeof err, err);
           }
           return;
         default:

--- a/src/server/pad-update.ts
+++ b/src/server/pad-update.ts
@@ -30,14 +30,18 @@ const debounceUpdate = debounce(async (pad: Pad): Promise<void> => {
           // todo
           return;
         case 'live':
-          await uploadText(
-            authorToken.token,
-            target,
-            `${pad.id}.r${pad.head}.txt`,
-            `${pad.id}.r${pad.head}.txt`,
-            `Text of ${pad.id} at revision ${pad.head}`,
-            pad.atext.text,
-          );
+          try {
+            await uploadText(
+              authorToken.token,
+              target,
+              `${pad.id}.r${pad.head}.txt`,
+              `${pad.id}.r${pad.head}.txt`,
+              `Text of ${pad.id} at revision ${pad.head}`,
+              pad.atext.text,
+            );
+          } catch (err: unknown) {
+            console.log('Error uploading text', credentials.author, pad.id, err);
+          }
           return;
         default:
           // todo what could possibly have happened here

--- a/src/server/pad-update.ts
+++ b/src/server/pad-update.ts
@@ -2,8 +2,9 @@
 
 import { debounce } from 'lodash';
 import { pluginSettings } from './settings';
-import { getSyncConfigs } from './database';
+import { getSyncConfigs, deleteSyncConfig } from './database';
 import { uploadText } from './permanent-client';
+import { getOrRefreshToken } from './permanent-oauth';
 import type { SyncConfigEnabled } from './database';
 
 interface Pad {
@@ -19,16 +20,30 @@ const debounceUpdate = debounce(async (pad: Pad): Promise<void> => {
 
   (await getSyncConfigs(pad.id))
     .filter((config): config is SyncConfigEnabled => config.sync === true)
-    .forEach(({ credentials, target }) => uploadText(
-      credentials.session,
-      credentials.mfa,
-      target,
-      `${pad.id}.r${pad.head}.txt`,
-      `${pad.id}.r${pad.head}.txt`,
-      `Text of ${pad.id} at revision ${pad.head}`,
-      pad.atext.text,
-    ));
-  // TODO: error handling to set invalid credentials on failure
+    .forEach(async ({ credentials, target }) => {
+      const authorToken = await getOrRefreshToken(credentials.author);
+      switch(authorToken.status) {
+        case 'missing':
+          deleteSyncConfig(pad.id, credentials.author);
+          return;
+        case 'refreshing':
+          // todo
+          return;
+        case 'live':
+          await uploadText(
+            authorToken.token,
+            target,
+            `${pad.id}.r${pad.head}.txt`,
+            `${pad.id}.r${pad.head}.txt`,
+            `Text of ${pad.id} at revision ${pad.head}`,
+            pad.atext.text,
+          );
+          return;
+        default:
+          // todo what could possibly have happened here
+          return;
+      }
+    });
 }, pluginSettings.waitMilliseconds);
 
 const padUpdate = (hookName: string, args: { pad: Pad }) => {

--- a/src/server/permanent-client.ts
+++ b/src/server/permanent-client.ts
@@ -4,7 +4,7 @@ import FormData from 'form-data';
 
 import { pluginSettings } from './settings';
 
-const { apiKey, baseUrl, padToken } = pluginSettings;
+const { baseUrl, padToken } = pluginSettings;
 
 const createClient = async (
   sessionToken: string,
@@ -13,7 +13,6 @@ const createClient = async (
   archiveNbr?: string,
 ): Promise<Permanent> => {
   const permanent = new Permanent({
-    apiKey,
     baseUrl,
     mfaToken,
     sessionToken,

--- a/src/server/permanent-client.ts
+++ b/src/server/permanent-client.ts
@@ -4,24 +4,10 @@ import FormData from 'form-data';
 
 import { pluginSettings } from './settings';
 
-const { baseUrl, padToken } = pluginSettings;
+import type { AuthorTokenLive } from './database';
+import type { AccessToken } from 'simple-oauth2';
 
-const createClient = async (
-  sessionToken: string,
-  mfaToken: string,
-  archiveId?: number,
-  archiveNbr?: string,
-): Promise<Permanent> => {
-  const permanent = new Permanent({
-    baseUrl,
-    mfaToken,
-    sessionToken,
-    archiveId,
-    archiveNbr,
-  });
-  await permanent.init();
-  return permanent;
-};
+const { baseUrl, padToken } = pluginSettings;
 
 const getOrCreateEtherpadFolder = async (permanent: Permanent) => {
   const appFolder = await permanent.folder.getAppFolder();
@@ -48,10 +34,13 @@ interface PermanentUploadTarget {
 }
 
 const getSyncTarget = async (
-  session: string,
-  mfa: string,
+  { token }: AuthorTokenLive,
 ): Promise<PermanentUploadTarget> => {
-  const permanent = await createClient(session, mfa);
+  const permanent = new Permanent({
+    accessToken: token,
+    baseUrl,
+  });
+  await permanent.init();
   const etherpadFolder = await getOrCreateEtherpadFolder(permanent);
   return {
     archiveId: permanent.getArchiveId() as number,
@@ -63,8 +52,7 @@ const getSyncTarget = async (
 };
 
 const uploadText = async (
-  session: string,
-  mfa: string,
+  accessToken: AccessToken,
   target: PermanentUploadTarget,
   displayName: string,
   filename: string,
@@ -80,7 +68,11 @@ const uploadText = async (
     uploadFileName: filename,
   };
 
-  const permanent = await createClient(session, mfa, target.archiveId, target.archiveNbr);
+  const permanent = new Permanent({
+    accessToken,
+    baseUrl,
+  });
+  await permanent.session.useArchive(target.archiveNbr);
   const { destinationUrl, presignedPost } = await permanent.record.getPresignedUrl('text/plain', record, padToken);
 
   const form = buildForm(presignedPost.fields, data);

--- a/src/server/permanent-oauth.ts
+++ b/src/server/permanent-oauth.ts
@@ -1,0 +1,84 @@
+import { PermanentOAuthClient } from '@permanentorg/node-sdk';
+import { deleteAuthorToken, getAuthorToken, setAuthorToken } from './database';
+import { pluginSettings } from './settings';
+import type { AccessToken } from 'simple-oauth2';
+
+import type {
+  AuthorToken,
+  AuthorTokenLive,
+  AuthorTokenRefreshing,
+  AuthorTokenValid,
+} from './database';
+
+const {
+  authHost, baseUrl, clientId, clientSecret,
+} = pluginSettings;
+
+const client = new PermanentOAuthClient(
+  clientId,
+  clientSecret,
+  baseUrl,
+  authHost,
+);
+
+const authorTokenIsLive = (token: AuthorToken): token is AuthorTokenLive => (
+  token.status === 'live'
+);
+
+const authorTokenIsValid = (token: AuthorToken): token is AuthorTokenValid => (
+  token.status === 'valid'
+);
+
+const getOrRefreshToken = async (author: string): Promise<AuthorToken> => {
+  try {
+    const authorToken = await getAuthorToken(author);
+    if (!authorTokenIsValid(authorToken)) {
+      return authorToken;
+    }
+
+    const token = client.loadToken(authorToken.token.toString());
+    if (!token.expired()) {
+      return {
+        status: 'live',
+        token,
+      }
+    }
+    if (!('refresh_token' in token.token)) {
+      // token has expired and it is not a refresh token
+      await deleteAuthorToken(author);
+      return {
+        status: 'missing',
+      };
+    }
+
+    // the token has expired, but we haven't tried to refresh it yet
+    const refreshingAuthorToken: AuthorTokenRefreshing = {
+      status: 'refreshing',
+      token: authorToken.token,
+    };
+    await setAuthorToken(author, refreshingAuthorToken);
+    setImmediate(() => {
+      console.log('Refreshing expired token', token.token);
+      token.token.refresh()
+        .then((refreshedToken: AccessToken) => {
+          console.log('Refreshed token', refreshedToken.token);
+          setAuthorToken(author, {
+            token: refreshedToken,
+            status: 'valid',
+          });
+        })
+        .catch((err: unknown) => {
+          console.log('Error while refreshing token for author', author, err);
+          return deleteAuthorToken(author);
+        });
+    });
+    return refreshingAuthorToken;
+  } catch (error: unknown) {
+    console.log('Error trying to determine if user is logged in to Permanent', typeof error, error);
+    return {
+      status: 'missing',
+    };
+  }
+};
+
+export { authorTokenIsLive, client, getOrRefreshToken };

--- a/src/server/permanent-oauth.ts
+++ b/src/server/permanent-oauth.ts
@@ -36,7 +36,7 @@ const getOrRefreshToken = async (author: string): Promise<AuthorToken> => {
       return authorToken;
     }
 
-    const token = client.loadToken(authorToken.token.toString());
+    const token = client.loadToken(JSON.stringify(authorToken.token));
     if (!token.expired()) {
       return {
         status: 'live',
@@ -58,12 +58,12 @@ const getOrRefreshToken = async (author: string): Promise<AuthorToken> => {
     };
     await setAuthorToken(author, refreshingAuthorToken);
     setImmediate(() => {
-      console.log('Refreshing expired token', token.token);
-      token.token.refresh()
+      console.log('getOrRefreshToken refreshing token');
+      token.refresh()
         .then((refreshedToken: AccessToken) => {
-          console.log('Refreshed token', refreshedToken.token);
+          console.log('getOrRefreshToken token refreshed', refreshedToken);
           setAuthorToken(author, {
-            token: refreshedToken,
+            token: refreshedToken.token,
             status: 'valid',
           });
         })

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -1,9 +1,12 @@
 import * as EtherpadSettings from 'ep_etherpad-lite/node/utils/Settings';
 
 interface PermanentExporterSettings {
+  authHost: string;
   baseUrl: string;
+  clientId: string;
+  clientSecret: string;
+  cookieSecret: string;
   padToken: string;
-  loginUrl: string;
   waitMilliseconds: number;
   wallet: string;
 }

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -1,7 +1,6 @@
 import * as EtherpadSettings from 'ep_etherpad-lite/node/utils/Settings';
 
 interface PermanentExporterSettings {
-  apiKey: string;
   baseUrl: string;
   padToken: string;
   loginUrl: string;

--- a/templates/exportColumn.html
+++ b/templates/exportColumn.html
@@ -19,6 +19,12 @@
       Please <a href="<%- loginUrl %>">log in</a> to your Permanent account!
     </div>
     <div
+      id="ep_permanent_exporter-log-in-pending"
+      class="ep_permanent_exporter-hidden"
+    >
+      Please wait while we validate your credentials.
+    </div>
+    <div
       id="ep_permanent_exporter-sync-disabled"
       class="ep_permanent_exporter-hidden"
     >

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,6 @@
       "es2018"
     ],
     "outDir": "static/js",
-    "sourceMap": true
+    "sourceMap": false
   }
 }


### PR DESCRIPTION
Replace the proof-of-concept cookie authentication, which required deployment to a subdomain of permanent.org, with proper authentication as an OAuth client.

Instead of saving cookies in the database to be used for later uploads triggered by changing synced pads, save OAuth tokens. Change the data model for sync configs to store pad => author and author => token, rather than pad => cookie, so that an author can re-log-in after the token has expired to re-enable syncing.

@cecilia-donnelly I'd appreciate some help testing this out; I think I have it working, but I'd appreciate a second pair of eyes!